### PR TITLE
Variable Mapping

### DIFF
--- a/Snail/Variable.swift
+++ b/Snail/Variable.swift
@@ -31,6 +31,12 @@ public class Variable<T> {
         return subject
     }
 
+    func map<U>(transform: @escaping (T) -> U) -> Unique<U> {
+        let newVariable = Unique<U>(transform(value))
+        asObservable().subscribe(onNext: { _ in newVariable.value = transform(self.value) })
+        return newVariable
+    }
+
     deinit {
         subject.on(.done)
     }

--- a/SnailTests/UniqueTests.swift
+++ b/SnailTests/UniqueTests.swift
@@ -36,7 +36,7 @@ class UniqueTests: XCTestCase {
     }
 
     func testVariableNotifiesInitialOnSubscribe() {
-        let subject = Unique<String?>("initial")
+        let subject = Unique("initial")
         var result: String?
 
         subject.asObservable().subscribe(onNext: { string in
@@ -44,6 +44,29 @@ class UniqueTests: XCTestCase {
         })
 
         XCTAssertEqual("initial", result)
+    }
+
+    func testMappedVariableNotifiesOnSubscribe() {
+        let subject = Unique("initial")
+        subject.value = "new"
+        var subjectCharactersCount: Int?
+
+        subject.map { $0.count }.asObservable().subscribe(onNext: { count in
+            subjectCharactersCount = count
+        })
+
+        XCTAssertEqual(subject.value.count, subjectCharactersCount)
+    }
+
+    func testMappedVariableNotifiesInitialOnSubscribe() {
+        let subject = Unique("initial")
+        var subjectCharactersCount: Int?
+
+        subject.map { $0.count }.asObservable().subscribe(onNext: { count in
+            subjectCharactersCount = count
+        })
+
+        XCTAssertEqual(subject.value.count, subjectCharactersCount)
     }
 
     func testVariableHandlesEquatableArrays() {

--- a/SnailTests/VariableTests.swift
+++ b/SnailTests/VariableTests.swift
@@ -41,4 +41,27 @@ class VariableTests: XCTestCase {
 
         XCTAssertEqual("initial", result)
     }
+
+    func testMappedVariableNotifiesOnSubscribe() {
+        let subject = Variable("initial")
+        subject.value = "new"
+        var subjectCharactersCount: Int?
+
+        subject.map { $0.count }.asObservable().subscribe(onNext: { count in
+            subjectCharactersCount = count
+        })
+
+        XCTAssertEqual(subject.value.count, subjectCharactersCount)
+    }
+
+    func testMappedVariableNotifiesInitialOnSubscribe() {
+        let subject = Variable("initial")
+        var subjectCharactersCount: Int?
+
+        subject.map { $0.count }.asObservable().subscribe(onNext: { count in
+            subjectCharactersCount = count
+        })
+
+        XCTAssertEqual(subject.value.count, subjectCharactersCount)
+    }
 }


### PR DESCRIPTION
I am suggesting this addition to `Snail`. This allows to map a `Unique<T>` into a `Unique<U>` that will receive the same notifications, with the `value` transformed from its initial type `T` to the expected new type `U`. 

This is useful for me [here](https://github.com/UrbanCompass/iOS/pull/5267/files#diff-1a9d36a2e243f5b3d0df42e597a9b59fR98) when I use:

```swift
public enum ValidationField {
    case binding(Variable<String?>) // expects a Variable of type <String?>
    // ...
}
```

But in my case, I need to bind `viewModel.showingAgent` which is of type `Unique<FullContact?>`. I don't want to create a new enumeration member taking that type specifically. I prefer to reuse that existing enumeration member and map `viewModel.showingAgent` into a `Unique<String?>`.

I think this could be useful in multiple places as well along the way 👍 