### PR TITLE
Add test for Fail

### DIFF
--- a/SnailTests/FailTests.swift
+++ b/SnailTests/FailTests.swift
@@ -43,9 +43,9 @@ class FailTests: XCTestCase {
     }
 
     func testFiresStoppedEventOnSubscribe() {
-        var newError: Error? = nil
+        var newError: Error?
         done = nil
-        
+
         subject?.subscribe(
             onError: { error in newError = error },
             onDone: { self.done = true }

--- a/SnailTests/FailTests.swift
+++ b/SnailTests/FailTests.swift
@@ -20,15 +20,15 @@ class FailTests: XCTestCase {
         strings = []
         error = nil
         done = nil
-        
+
         subject?.subscribe(
             queue: nil,
-            onNext: { [weak self] string in self?.strings?.append(string) },
-            onError: { error in self.error = error },
+            onNext: { [weak self] in self?.strings?.append($0) },
+            onError: { self.error = $0 },
             onDone: { self.done = true }
         )
     }
-    
+
     func testOnErrorIsRun() {
         XCTAssertEqual((error as? TestError), TestError.test)
     }
@@ -37,11 +37,11 @@ class FailTests: XCTestCase {
         subject?.on(.next("1"))
         XCTAssertEqual(strings?.count, 0)
     }
-    
+
     func testOnDoneIsNotRun() {
         XCTAssertNil(done)
     }
-    
+
     func testFiresStoppedEventOnSubscribe() {
         var newError: Error? = nil
         done = nil
@@ -50,7 +50,7 @@ class FailTests: XCTestCase {
             onError: { error in newError = error },
             onDone: { self.done = true }
         )
-        
+
         XCTAssertNotNil(newError as? TestError)
         XCTAssertEqual(newError as? TestError, error as? TestError)
         XCTAssertNil(done)

--- a/SnailTests/FailTests.swift
+++ b/SnailTests/FailTests.swift
@@ -18,14 +18,41 @@ class FailTests: XCTestCase {
         super.setUp()
         subject = Fail(TestError.test)
         strings = []
-        subject?.subscribe(onNext: { [weak self] string in self?.strings?.append(string) })
+        error = nil
+        done = nil
+        
+        subject?.subscribe(
+            queue: nil,
+            onNext: { [weak self] string in self?.strings?.append(string) },
+            onError: { error in self.error = error },
+            onDone: { self.done = true }
+        )
+    }
+    
+    func testOnErrorIsRun() {
+        XCTAssertEqual((error as? TestError), TestError.test)
     }
 
-    func testFail() {
-        subject?
-            .subscribe(onError: { error in self.error = error })
+    func testOnNextIsNotRun() {
         subject?.on(.next("1"))
-        XCTAssert(strings?.count == 0)
-        XCTAssert((error as? TestError) == TestError.test)
+        XCTAssertEqual(strings?.count, 0)
+    }
+    
+    func testOnDoneIsNotRun() {
+        XCTAssertNil(done)
+    }
+    
+    func testFiresStoppedEventOnSubscribe() {
+        var newError: Error? = nil
+        done = nil
+        
+        subject?.subscribe(
+            onError: { error in newError = error },
+            onDone: { self.done = true }
+        )
+        
+        XCTAssertNotNil(newError as? TestError)
+        XCTAssertEqual(newError as? TestError, error as? TestError)
+        XCTAssertNil(done)
     }
 }


### PR DESCRIPTION
I thought there might be some bugs or extraneous code for `Fail` and `Unique`, but after trying to produce the bugs/going through the tests, I'm convinced that they are working as intended.

This commit is just some work that I did as a byproduct that might add value. Just adds a test for `Fail` and splits the existing test into smaller units.