### PR TITLE
Addition Bind Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ int.asObservable().subscribe(
 int.value = 42
 ```
 
+```swift
+let isLoaderAnimating = Variable<Bool>(false)
+isLoaderAnimating.bind(to: viewModel.isLoading) // forward changes from one Variable to another
+
+viewModel.isLoading = true
+print(isLoaderAnimating.value) // true
+```
+
 ## Transforming Observable Variable Types
 
 
@@ -105,7 +113,7 @@ let just = Just(1) // always returns the initial value (1 in this case)
 enum TestError: Error {
   case test
 }
-let failure = Fail(TestError.test) //always fail with error
+let failure = Fail(TestError.test) // always fail with error
 
 let n = 5
 let replay = Replay(n) // replays the last N events when a new observer subscribes

--- a/Snail/Variable.swift
+++ b/Snail/Variable.swift
@@ -31,6 +31,12 @@ public class Variable<T> {
         return subject
     }
 
+    public func bind(to variable: Variable<T>) {
+        variable.asObservable().subscribe(onNext: { [weak self] value in
+            self?.value = value
+        })
+    }
+
     public func map<U>(transform: @escaping (T) -> U) -> Variable<U> {
         let newVariable = Variable<U>(transform(value))
         asObservable().subscribe(onNext: { _ in newVariable.value = transform(self.value) })

--- a/SnailTests/VariableTests.swift
+++ b/SnailTests/VariableTests.swift
@@ -101,4 +101,15 @@ class VariableTests: XCTestCase {
 
         XCTAssertTrue(fired)
     }
+
+    func testBindToOtherVariable() {
+        let subject = Variable("one")
+        let observedVariable = Variable("two")
+
+        subject.bind(to: observedVariable)
+        XCTAssertEqual(subject.value, "two")
+
+        observedVariable.value = "three"
+        XCTAssertEqual(subject.value, "three")
+    }
 }


### PR DESCRIPTION
### Description

We had this discussion some time ago on [Slack](https://compass-tech.slack.com/archives/G4FC531U3/p1551124277150100), regarding adding this helper / convenient function that removes unnecessarily / cumbersome binding code. 

We would replace:

```swift
userService.isRefreshing.asObservable().subscribe(onNext: { [weak self] isRefreshing in
     self?.loadingMap.value = isRefreshing
})
```

By this single line:

```swift
loadingMap.bind(to: userService.isRefreshing)
```

**Note:** some of the other suggestions that were "not preferred" by the team: 

```swift
// Custom operator
loadingMap <~ userService.isRefreshing
```

```swift
// Static function
Observable.bind(loadingMap, to: userService.isRefreshing)
```

```swift
// Free function
bind(loadingMap, to: userService.isRefreshing)
```