### PR TITLE
Addition Combine Latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,33 @@ int.asObservable().subscribe(
 int.value = 42
 ```
 
+## Combining Observable Variables
+
+
 ```swift
 let isLoaderAnimating = Variable<Bool>(false)
 isLoaderAnimating.bind(to: viewModel.isLoading) // forward changes from one Variable to another
 
 viewModel.isLoading = true
 print(isLoaderAnimating.value) // true
+```
+
+```swift
+Observable.merge([userCreated, userUpdated]).subscribe(
+  onNext: { user in ... } // do something with the latest value that got updated
+})
+
+userCreated.value = User(name: "Russell") // triggers 
+userUpdated.value = User(name: "Lee") // triggers 
+```
+
+```swift
+Observable.combineLatest((isMapLoading, isListLoading)).subscribe(
+  onNext: { isMapLoading, isListLoading in ... } // do something when both values are set, every time one gets updated
+})
+
+isMapLoading.value = true
+isListLoading.value = true // triggers
 ```
 
 ## Transforming Observable Variable Types

--- a/Snail/Observable.swift
+++ b/Snail/Observable.swift
@@ -163,11 +163,11 @@ public class Observable<T> : ObservableType {
         return latest
     }
 
-    public static func combineLatest<A: Any, B: Any>(_ observables: (Observable<A>, Observable<B>)) -> Observable<(A, B)> {
-        let combined = Observable<(A, B)>()
+    public static func combineLatest<U>(_ input: (Observable<T>, Observable<U>)) -> Observable<(T, U)> {
+        let combined = Observable<(T, U)>()
 
-        var value0: A?
-        var value1: B?
+        var value0: T?
+        var value1: U?
 
         func triggerIfNeeded() {
             if let value0 = value0, let value1 = value1 {
@@ -175,7 +175,7 @@ public class Observable<T> : ObservableType {
             }
         }
 
-        observables.0.subscribe(onNext: {
+        input.0.subscribe(onNext: {
             value0 = $0
             triggerIfNeeded()
         }, onError: {
@@ -184,7 +184,7 @@ public class Observable<T> : ObservableType {
             combined.on(.done)
         })
 
-        observables.1.subscribe(onNext: {
+        input.1.subscribe(onNext: {
             value1 = $0
             triggerIfNeeded()
         }, onError: {

--- a/SnailTests/ObservableTests.swift
+++ b/SnailTests/ObservableTests.swift
@@ -400,6 +400,38 @@ class ObservableTests: XCTestCase {
             XCTAssert(received[3] == "<no title>: 3")
         }
     }
+
+    func testCombineLatestError() {
+        let exp = expectation(description: "combineLatest")
+
+        var received: [String] = []
+
+        let string = Observable<String>()
+        let int = Observable<Int>()
+
+        let subject = Observable.combineLatest((string, int))
+
+        subject.subscribe(onNext: { string, int in
+            received.append("\(string): \(int)")
+        }, onError: { _ in
+            received.append("ERROR")
+        }, onDone: {
+            exp.fulfill()
+        })
+
+        string.on(.next("The number"))
+        int.on(.next(1))
+        string.on(.error(TestError.test))
+        string.on(.next("The digit"))
+        int.on(.next(3))
+        int.on(.done)
+
+        waitForExpectations(timeout: 1) { _ in
+            XCTAssert(received.count == 2)
+            XCTAssert(received.first == "The number: 1")
+            XCTAssert(received.last == "ERROR")
+        }
+    }
 }
 
 // swiftlint:enable file_length

--- a/SnailTests/ObservableTests.swift
+++ b/SnailTests/ObservableTests.swift
@@ -332,4 +332,36 @@ class ObservableTests: XCTestCase {
             XCTAssert(received.last == "2")
         }
     }
+
+    func testCombineLatestNonOptional() {
+        let exp = expectation(description: "merge")
+
+        var received: [String] = []
+
+        let string = Observable<String>()
+        let int = Observable<Int>()
+
+        let subject = Observable.combineLatest((string, int))
+
+        subject.subscribe(onNext: { string, int in
+            received.append("\(string): \(int)")
+        }, onDone: {
+            exp.fulfill()
+        })
+
+        string.on(.next("The number"))
+        int.on(.next(1))
+        int.on(.next(2))
+        string.on(.next("The digit"))
+        int.on(.next(3))
+        int.on(.done)
+
+        waitForExpectations(timeout: 1) { _ in
+            XCTAssert(received.count == 4)
+            XCTAssert(received[0] == "The number: 1")
+            XCTAssert(received[1] == "The number: 2")
+            XCTAssert(received[2] == "The digit: 2")
+            XCTAssert(received[3] == "The digit: 3")
+        }
+    }
 }

--- a/SnailTests/ObservableTests.swift
+++ b/SnailTests/ObservableTests.swift
@@ -1,5 +1,7 @@
 //  Copyright © 2016 Compass. All rights reserved.
 
+// swiftlint:disable file_length
+
 import Foundation
 import XCTest
 @testable import Snail
@@ -334,7 +336,7 @@ class ObservableTests: XCTestCase {
     }
 
     func testCombineLatestNonOptional() {
-        let exp = expectation(description: "merge")
+        let exp = expectation(description: "combineLatest")
 
         var received: [String] = []
 
@@ -367,7 +369,7 @@ class ObservableTests: XCTestCase {
     }
 
     func testCombineLatestOptional() {
-        let exp = expectation(description: "merge")
+        let exp = expectation(description: "combineLatest")
 
         var received: [String] = []
 
@@ -399,3 +401,5 @@ class ObservableTests: XCTestCase {
         }
     }
 }
+
+// swiftlint:enable file_length

--- a/SnailTests/ObservableTests.swift
+++ b/SnailTests/ObservableTests.swift
@@ -349,6 +349,7 @@ class ObservableTests: XCTestCase {
             exp.fulfill()
         })
 
+        string.on(.next("The value"))
         string.on(.next("The number"))
         int.on(.next(1))
         int.on(.next(2))
@@ -362,6 +363,39 @@ class ObservableTests: XCTestCase {
             XCTAssert(received[1] == "The number: 2")
             XCTAssert(received[2] == "The digit: 2")
             XCTAssert(received[3] == "The digit: 3")
+        }
+    }
+
+    func testCombineLatestOptional() {
+        let exp = expectation(description: "merge")
+
+        var received: [String] = []
+
+        let string = Observable<String?>()
+        let int = Observable<Int?>()
+
+        let subject = Observable.combineLatest((string, int))
+
+        subject.subscribe(onNext: { string, int in
+            received.append("\(string ?? "<no title>"): \(int ?? 0)")
+        }, onDone: {
+            exp.fulfill()
+        })
+
+        string.on(.next("The value"))
+        string.on(.next("The number"))
+        int.on(.next(1))
+        int.on(.next(nil))
+        string.on(.next(nil))
+        int.on(.next(3))
+        int.on(.done)
+
+        waitForExpectations(timeout: 1) { _ in
+            XCTAssert(received.count == 4)
+            XCTAssert(received[0] == "The number: 1")
+            XCTAssert(received[1] == "The number: 0")
+            XCTAssert(received[2] == "<no title>: 0")
+            XCTAssert(received[3] == "<no title>: 3")
         }
     }
 }


### PR DESCRIPTION
### Description

This is a `Observable.combineLatest` proposition of implementation for Snail. This comes as a follow up of `Observable.merge` implemented recently. You can see more details of what it is doing [here](http://reactivex.io/documentation/operators/combinelatest.html).

![image](https://user-images.githubusercontent.com/16304947/54545803-c0bc9b80-4978-11e9-9c33-36e4ce0db106.png)

It would replace:

```swift
viewModel.isMapLoading.asObservable().subscribe(onNext: { [weak self] _ in self?.updateLoadingState() })

viewModel.isListLoading.asObservable().subscribe(onNext: { [weak self] _ in self?.updateLoadingState() })

private func updateLoadingState() {
     if self?.isMapLoading.value == true || self?.isListLoading.value == true {
          activityIndicator.startAnimating()
     } else {
          activityIndicator.stopAnimating()
     }
}
```

By this simpler expression:

```swift
Observable.combineLatest((isMapLoading, isListLoading)).subscribe(onNext: { [weak self] isMapLoading, isListLoading in
     if isMapLoading || isListLoading {
          self?.activityIndicator.startAnimating()
     } else {
          self?.activityIndicator.stopAnimating()
     }
})
```

### Enhancements

**1/** With this current version, we are limited to only 2 `Observable` objects as input. We might in the future want to combine more than 2 signals 

**2/** Ideally I would prefer to pass an `Array` of `Observable` objects as parameter, instead of currently a tuple. But I don't know if the language will allow me to do that, because each `Observer` might have a different generic type associated

Currently:

```swift
public static func combineLatest<U>(_ input: (Observable<T>, Observable<U>)) -> Observable<(T, U)>
```

What I would like:

```swift
public static func combineLatest<???>(_ input: [Observable<???>]) -> Observable<[???]>
```

I do know that _ReactiveSwift_ takes a limited `n` number of signals in input of their `combineLatest` (I think 16). So I imagine they encountered the same challenge, and might have multiple declarations, one for each number of signals in input...

**3/** I would like to remove the duplicated code as well (subscription and forward for each tuple member)

Let me guys know if you have suggestions!