### PR TITLE
Add the Observable to the Subscriber

### DIFF
--- a/Snail/Fail.swift
+++ b/Snail/Fail.swift
@@ -12,7 +12,7 @@ public class Fail<T>: Observable<T> {
 
     @discardableResult public override func subscribe(queue: DispatchQueue? = nil, onNext: ((T) -> Void)?, onError: ((Error) -> Void)?, onDone: (() -> Void)?) -> Subscriber<T> {
         let handler = createHandler(onNext: onNext, onError: onError, onDone: onDone)
-        let subscriber = Subscriber(queue: queue, handler: handler)
+        let subscriber = Subscriber(queue: queue, observable: self, handler: handler)
         notify(subscriber: subscriber, event: .error(error))
         return subscriber
     }

--- a/Snail/Just.swift
+++ b/Snail/Just.swift
@@ -13,7 +13,7 @@ public class Just<T>: Observable<T> {
 
     @discardableResult public override func subscribe(queue: DispatchQueue? = nil, onNext: ((T) -> Void)? = nil, onError: ((Error) -> Void)? = nil, onDone: (() -> Void)? = nil) -> Subscriber<T> {
         let handler = createHandler(onNext: onNext, onError: onError, onDone: onDone)
-        let subscriber = Subscriber(queue: queue, handler: handler)
+        let subscriber = Subscriber(queue: queue, observable: self, handler: handler)
         notify(subscriber: subscriber, event: .next(value))
         notify(subscriber: subscriber, event: .done)
         return subscriber

--- a/Snail/Observable.swift
+++ b/Snail/Observable.swift
@@ -21,7 +21,7 @@ public class Observable<T>: ObservableType {
     }
 
     @discardableResult public func subscribe(queue: DispatchQueue? = nil, onNext: ((T) -> Void)? = nil, onError: ((Error) -> Void)? = nil, onDone: (() -> Void)? = nil) -> Subscriber<T> {
-        let subscriber = Subscriber(queue: queue, handler: createHandler(onNext: onNext, onError: onError, onDone: onDone))
+        let subscriber = Subscriber(queue: queue, observable: self, handler: createHandler(onNext: onNext, onError: onError, onDone: onDone))
         if let stoppedEvent = stoppedEvent {
             notify(subscriber: subscriber, event: stoppedEvent)
             return subscriber

--- a/Snail/Replay.swift
+++ b/Snail/Replay.swift
@@ -36,6 +36,6 @@ public class Replay<T>: Observable<T> {
     }
 
     private func replay(queue: DispatchQueue?, handler: @escaping (Event<T>) -> Void) {
-        events.forEach { event in notify(subscriber: Subscriber(queue: queue, handler: handler), event: event) }
+        events.forEach { event in notify(subscriber: Subscriber(queue: queue, observable: self, handler: handler), event: event) }
     }
 }

--- a/Snail/Subscriber.swift
+++ b/Snail/Subscriber.swift
@@ -5,9 +5,11 @@ import Foundation
 public class Subscriber<T> {
     let queue: DispatchQueue?
     let handler: (Event<T>) -> Void
+    weak var observable: Observable<T>?
 
-    public init(queue: DispatchQueue?, handler: @escaping (Event<T>) -> Void) {
+    public init(queue: DispatchQueue?, observable: Observable<T>, handler: @escaping (Event<T>) -> Void) {
         self.queue = queue
         self.handler = handler
+        self.observable = observable
     }
 }


### PR DESCRIPTION
* By having the observable that I'm subscribed to, I'm able to unsubscribe myself
* This is useful for _dispose bag_ approach where one function can eliminate several closures from different observables