### PR TITLE
Removing @DiscardableResult

### DIFF
--- a/Snail/Replay.swift
+++ b/Snail/Replay.swift
@@ -11,7 +11,7 @@ public class Replay<T>: Observable<T> {
         self.threshold = threshold
     }
 
-    @discardableResult public override func subscribe(queue: DispatchQueue? = nil, onNext: ((T) -> Void)? = nil, onError: ((Error) -> Void)? = nil, onDone: (() -> Void)? = nil) -> Subscriber<T> {
+    public override func subscribe(queue: DispatchQueue? = nil, onNext: ((T) -> Void)? = nil, onError: ((Error) -> Void)? = nil, onDone: (() -> Void)? = nil) -> Subscriber<T> {
         replay(queue: queue, handler: createHandler(onNext: onNext, onError: onError, onDone: onDone))
         return super.subscribe(queue: queue, onNext: onNext, onError: onError, onDone: onDone)
     }
@@ -28,7 +28,7 @@ public class Replay<T>: Observable<T> {
 
     public override func on(_ queue: DispatchQueue) -> Observable<T> {
         let replay = Replay<T>(threshold)
-        subscribe(queue: queue,
+        _ = subscribe(queue: queue,
                   onNext: { replay.on(.next($0)) },
                   onError: { replay.on(.error($0)) },
                   onDone: { replay.on(.done) })

--- a/SnailTests/ReplayTests.swift
+++ b/SnailTests/ReplayTests.swift
@@ -21,8 +21,7 @@ class ReplayTests: XCTestCase {
         subject?.on(.next("1"))
         subject?.on(.next("2"))
         subject?.on(.done)
-        subject?
-            .subscribe(onNext: { string in strings.append(string) })
+        _ = subject?.subscribe(onNext: { string in strings.append(string) })
         XCTAssert(strings[0] == "1")
         XCTAssert(strings[1] == "2")
     }
@@ -32,11 +31,11 @@ class ReplayTests: XCTestCase {
         var more: [String] = []
         subject?.on(.next("1"))
         subject?.on(.next("2"))
-        subject?.subscribe(onNext: { string in
+        _ = subject?.subscribe(onNext: { string in
             strings.append(string)
         })
         subject?.on(.next("3"))
-        subject?.subscribe(onNext: { string in
+        _ = subject?.subscribe(onNext: { string in
             more.append(string)
         })
         XCTAssert(strings[0] == "1")
@@ -50,7 +49,7 @@ class ReplayTests: XCTestCase {
 
         subject?.on(.next("1"))
         DispatchQueue.global().async {
-            self.subject?.subscribe(queue: .main, onNext: { _ in
+            _ = self.subject?.subscribe(queue: .main, onNext: { _ in
                 exp.fulfill()
                 isMainQueue = Thread.isMainThread
             })


### PR DESCRIPTION
* We're removing `@discardableResult` to make evident that subscriptions need to be added to a `Disposer` 