### PR TITLE
Make Gesture Recognizers send same information as Target-Action in Observable

### DIFF
--- a/Snail/Extensions/UIGestureRecognizerExtensions.swift
+++ b/Snail/Extensions/UIGestureRecognizerExtensions.swift
@@ -6,19 +6,19 @@ import UIKit
 extension UIGestureRecognizer {
     private static var observableKey = "com.compass.Snail.UIGestureRecognizer.ObservableKey"
 
-    public func asObservable() -> Observable<UIGestureRecognizer.State> {
-        if let observable = objc_getAssociatedObject(self, &UIGestureRecognizer.observableKey) as? Observable<UIGestureRecognizer.State> {
+    public func asObservable() -> Observable<(UIGestureRecognizer, UIEvent)> {
+        if let observable = objc_getAssociatedObject(self, &UIGestureRecognizer.observableKey) as? Observable<(UIGestureRecognizer, UIEvent)> {
             return observable
         }
-        let observable = Observable<UIGestureRecognizer.State>()
+        let observable = Observable<(UIGestureRecognizer, UIEvent)>()
         objc_setAssociatedObject(self, &UIGestureRecognizer.observableKey, observable, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         addTarget(self, action: #selector(observableHandler))
         return observable
     }
 
-    @objc private func observableHandler() {
-        if let observable = objc_getAssociatedObject(self, &UIGestureRecognizer.observableKey) as? Observable<UIGestureRecognizer.State> {
-            observable.on(.next(state))
+    @objc private func observableHandler(sender: UIGestureRecognizer, event: UIEvent) {
+        if let observable = objc_getAssociatedObject(self, &UIGestureRecognizer.observableKey) as? Observable<(UIGestureRecognizer, UIEvent)> {
+            observable.on(.next((sender, event)))
         }
     }
 }


### PR DESCRIPTION
Apple gives you the [sender and event](https://developer.apple.com/documentation/uikit/uicontrol#1943645) when the action is called, but our observable only gives back the sender state. There's a lot of useful information in the gesture recognizer. Because the observable doesn't provide it, the user would need to try to awkwardly capture it themselves which could lead to retain cycle and life-cycle related bugs.