### PR TITLE
Fix crash on gesture recognizer

### DIFF
--- a/Snail/Extensions/UIGestureRecognizerExtensions.swift
+++ b/Snail/Extensions/UIGestureRecognizerExtensions.swift
@@ -6,19 +6,19 @@ import UIKit
 extension UIGestureRecognizer {
     private static var observableKey = "com.compass.Snail.UIGestureRecognizer.ObservableKey"
 
-    public func asObservable() -> Observable<(UIGestureRecognizer, UIEvent)> {
-        if let observable = objc_getAssociatedObject(self, &UIGestureRecognizer.observableKey) as? Observable<(UIGestureRecognizer, UIEvent)> {
+    public func asObservable() -> Observable<UIGestureRecognizer> {
+        if let observable = objc_getAssociatedObject(self, &UIGestureRecognizer.observableKey) as? Observable<UIGestureRecognizer> {
             return observable
         }
-        let observable = Observable<(UIGestureRecognizer, UIEvent)>()
+        let observable = Observable<UIGestureRecognizer>()
         objc_setAssociatedObject(self, &UIGestureRecognizer.observableKey, observable, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         addTarget(self, action: #selector(observableHandler))
         return observable
     }
 
-    @objc private func observableHandler(sender: UIGestureRecognizer, event: UIEvent) {
-        if let observable = objc_getAssociatedObject(self, &UIGestureRecognizer.observableKey) as? Observable<(UIGestureRecognizer, UIEvent)> {
-            observable.on(.next((sender, event)))
+    @objc private func observableHandler(_ sender: UIGestureRecognizer) {
+        if let observable = objc_getAssociatedObject(self, &UIGestureRecognizer.observableKey) as? Observable<UIGestureRecognizer> {
+            observable.on(.next(sender))
         }
     }
 }


### PR DESCRIPTION
Turns out action messages to `UIGestureRecognizer` don't support `UIEvent` like action messages to `UIControl` does.

https://developer.apple.com/documentation/uikit/uigesturerecognizer

> The action methods invoked must conform to one of the following signatures:
> 
> @IBAction func myActionMethod()
> @IBAction func myActionMethod(_ sender: UIGestureRecognizer)