### PR TITLE
Add swift-tools-version, update gitignore, update Package.swift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ xcuserdata
 
 # Swift Package Manager
 .build/
+.swiftpm
 
 # Carthage
 Carthage/Build

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,3 @@
-// swift-tools-version:4.2
 // swift-tools-version:5.2
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,15 @@
+// swift-tools-version:4.2
+// swift-tools-version:5.2
+
 import PackageDescription
 
 let package = Package(
     name: "Snail",
-    exclude: ["Carthage", " Snail.xcodeproj", "SnailTests", "circle.yml", "codecov.yml"]
+    products: [
+        .library(name: "Snail", targets: ["Snail"]),
+    ],
+    targets: [
+        .target(name: "Snail", path: "Snail"),
+        .testTarget(name: "SnailTests", dependencies: ["Snail"], path: "SnailTests")
+    ]
 )


### PR DESCRIPTION
Hey! Hope you guys are doing well :D!

I was moving a project over to use SPM and noticed a few errors when I added Snail.

1. Looks like `Package.swift` [must begin](https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#about-the-swift-tools-version) with `swift-tools-version: `. I set the version to `4.2` and `5.2` but I'm happy to change that to whatever you guys want :).
2. Looks like `exclude` isn't a parameter in the `Package` initializer (I'm not sure when that changed)?
    <details>
    <summary>Error with `exclude`</summary>

    ![snail-exclude-error](https://user-images.githubusercontent.com/10577783/87268730-2b141c00-c499-11ea-9cdc-4c3a45b4fe67.png)

    </details>

3. Added `.swiftpm/` to the gitignore as per [this](https://forums.swift.org/t/files-created-when-opening-spm-package-in-xcode-11/28589/2)