### PR TITLE
Add map, filter and flatMap operators to Observable

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,3 +3,4 @@ disabled_rules:
   - type_name
   - identifier_name
   - type_body_length
+  - large_tuple

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "Snail",
     products: [
-        .library(name: "Snail", targets: ["Snail"]),
+        .library(name: "Snail", targets: ["Snail"])
     ],
     targets: [
         .target(name: "Snail", path: "Snail"),

--- a/README.md
+++ b/README.md
@@ -143,16 +143,6 @@ isMapLoading.value = true
 isListLoading.value = true // triggers
 ```
 
-## Transforming Observable Variable Types
-
-
-```swift
-let variable = Variable<String>("Something")
-variable.map { $0.count }.asObservable().subscribe(
-    onNext: { (charactersCount: Int -> Void) in ... } // do something with Integer 'charactersCount' on value changes
-).add(to: disposer)
-```
-
 ## Miscellaneous Observables
 
 ```swift
@@ -166,6 +156,32 @@ let failure = Fail(TestError.test) // always fail with error
 let n = 5
 let replay = Replay(n) // replays the last N events when a new observer subscribes
 ```
+
+## Operators
+
+Snail provides some basic operators in order to transform and operate on observables. 
+
+- `map`: This operator allows to map the value of an obsverable into another value. Similar to `map` on `Collection` types.
+
+  ```swift
+  let observable = Observable<Int>()
+  let subject = observable.map { "Number: \($0)" }
+  // -> subject emits `String` whenever `observable` emits.
+  ```
+- `filter`: This operator allows filtering out certain values from the observable chain. Similar to `filter` on `Collection` types. You simply return `true` if the value should be emitted and `false` to filter it out.
+
+  ```swift
+  let observable = Observable<Int>()
+  let subject = observable.filter { $0 % 2 == 0 }
+  // -> subject will only emit even numbers.
+  ```
+- `flatMap`: This operator allows mapping values into other observables, for example you may want to create an observable for a network request when a user tap observable emits.
+
+  ```swift
+  let fetchTrigger = Observable<Void>()
+  let subject = fetchTrigger.flatMap { Variable(100).asObservable() }
+  // -> subject is an `Observable<Int>` that is created when `fetchTrigger` emits.
+  ```
 
 ## Subscribing to Control Events
 

--- a/Snail/Extensions/UIViewControllerExtensions.swift
+++ b/Snail/Extensions/UIViewControllerExtensions.swift
@@ -1,10 +1,9 @@
 //  Copyright © 2016 Compass. All rights reserved.
 
-#if os(iOS) || os(tvOS)
-import UIKit
-#else
+#if canImport(UIKit)
+
 import Foundation
-#endif
+import UIKit
 
 extension UIViewController {
     private static var disposerKey = "com.compass.Snail.UIViewController.disposer"
@@ -18,3 +17,5 @@ extension UIViewController {
         return disposer
     }
 }
+
+#endif

--- a/Snail/Observable.swift
+++ b/Snail/Observable.swift
@@ -120,15 +120,15 @@ public class Observable<T>: ObservableType {
         return filtered
     }
 
-    public func block() -> (result: T?, error: Error?) {
+    public func block() -> Result<T?, Error> {
         performBlock(timeout: nil)
     }
 
-    public func block(timeout: TimeInterval) -> (result: T?, error: Error?) {
+    public func block(timeout: TimeInterval) -> Result<T?, Error> {
         performBlock(timeout: timeout)
     }
 
-    private func performBlock(timeout: TimeInterval?) -> (result: T?, error: Error?) {
+    private func performBlock(timeout: TimeInterval?) -> Result<T?, Error> {
         var result: T?
         var error: Error?
 
@@ -150,7 +150,15 @@ public class Observable<T>: ObservableType {
             _ = semaphore.wait()
         }
 
-        return (result, error)
+        if let error = error {
+            return .failure(error)
+        }
+
+        if let result = result {
+            return .success(result)
+        }
+
+        return .success(nil)
     }
 
     public func throttle(_ delay: TimeInterval) -> Observable<T> {
@@ -278,12 +286,9 @@ public class Observable<T>: ObservableType {
         return combined
     }
 
-    public static func combineLatest<U, V>(
-        _ input1: Observable<T>,
-        _ input2: Observable<U>,
-        _ input3: Observable<V>
-        // swiftlint:disable:next large_tuple
-    ) -> Observable<(T, U, V)> {
+    public static func combineLatest<U, V>(_ input1: Observable<T>,
+                                           _ input2: Observable<U>,
+                                           _ input3: Observable<V>) -> Observable<(T, U, V)> {
         let combined = Observable<(T, U, V)>()
 
         var value1: T?
@@ -329,13 +334,10 @@ public class Observable<T>: ObservableType {
         return combined
     }
 
-    public static func combineLatest<U, V, K>(
-        _ input1: Observable<T>,
-        _ input2: Observable<U>,
-        _ input3: Observable<V>,
-        _ input4: Observable<K>
-        // swiftlint:disable:next large_tuple
-    ) -> Observable<(T, U, V, K)> {
+    public static func combineLatest<U, V, K>(_ input1: Observable<T>,
+                                              _ input2: Observable<U>,
+                                              _ input3: Observable<V>,
+                                              _ input4: Observable<K>) -> Observable<(T, U, V, K)> {
         let combined = Observable<(T, U, V, K)>()
 
         var value1: T?

--- a/Snail/ObservableType.swift
+++ b/Snail/ObservableType.swift
@@ -10,7 +10,7 @@ public protocol ObservableType {
     func on(_ queue: DispatchQueue) -> Observable<Self.T>
     func removeSubscribers()
     func removeSubscriber(subscriber: Subscriber<T>)
-    func block() -> (result: Self.T?, error: Error?)
+    func block() -> Result<T?, Error>
     func throttle(_ delay: TimeInterval) -> Observable<Self.T>
     func debounce(_ delay: TimeInterval) -> Observable<Self.T>
     func forward(to: Observable<Self.T>)

--- a/Snail/Variable.swift
+++ b/Snail/Variable.swift
@@ -37,7 +37,7 @@ public class Variable<T> {
         })
     }
 
-    public func map<U>(transform: @escaping (T) -> U) -> Variable<U> {
+    public func map<U>(_ transform: @escaping (T) -> U) -> Variable<U> {
         let newVariable = Variable<U>(transform(value))
         asObservable().subscribe(onNext: { _ in newVariable.value = transform(self.value) })
         return newVariable

--- a/SnailTests/Extensions/NotificationCenterExtensions.swift
+++ b/SnailTests/Extensions/NotificationCenterExtensions.swift
@@ -1,5 +1,7 @@
 //  Copyright © 2016 Compass. All rights reserved.
 
+#if canImport(UIKit)
+
 import UIKit
 import XCTest
 @testable import Snail
@@ -46,3 +48,5 @@ class NotificationCenterTests: XCTestCase {
         }
     }
 }
+
+#endif

--- a/SnailTests/ObservableTests.swift
+++ b/SnailTests/ObservableTests.swift
@@ -547,7 +547,19 @@ class ObservableTests: XCTestCase {
         XCTAssertEqual(received[0].2, 100.5)
     }
 
-    func testCombineLatest3Error() {
+    func testCombineLatest3Error_fromSecondMember() {
+        let one = Observable<String>()
+        let two = Observable<Int>()
+        let three = Observable<Double>()
+        let subject = Observable.combineLatest(one, two, three)
+
+        let exp = expectation(description: "combineLatest3 forwards error from observable")
+        subject.subscribe(onError: { _ in exp.fulfill() })
+        two.on(.error(TestError.test))
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCombineLatest3Error_fromThirdMember() {
         let one = Observable<String>()
         let two = Observable<Int>()
         let three = Observable<Double>()
@@ -559,7 +571,19 @@ class ObservableTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
-    func testCombineLatest3Done() {
+    func testCombineLatest3Done_fromSecondMember() {
+        let one = Observable<String>()
+        let two = Observable<Int>()
+        let three = Observable<Double>()
+        let subject = Observable.combineLatest(one, two, three)
+
+        let exp = expectation(description: "combineLatest3 forwards done from observable")
+        subject.subscribe(onDone: { exp.fulfill() })
+        two.on(.done)
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCombineLatest3Done_fromThirdMember() {
         let one = Observable<String>()
         let two = Observable<Int>()
         let three = Observable<Double>()
@@ -624,7 +648,46 @@ class ObservableTests: XCTestCase {
         XCTAssertEqual(received[0].3, "The other string")
     }
 
-    func testCombineLatest4Error() {
+    func testCombineLatest4Error_fromFirstMember() {
+        let one = Observable<String>()
+        let two = Observable<Int>()
+        let three = Observable<Double>()
+        let four = Observable<String>()
+        let subject = Observable.combineLatest(one, two, three, four)
+
+        let exp = expectation(description: "combineLatest4 forwards error from observable")
+        subject.subscribe(onError: { _ in exp.fulfill() })
+        one.on(.error(TestError.test))
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCombineLatest4Error_fromSecondMember() {
+        let one = Observable<String>()
+        let two = Observable<Int>()
+        let three = Observable<Double>()
+        let four = Observable<String>()
+        let subject = Observable.combineLatest(one, two, three, four)
+
+        let exp = expectation(description: "combineLatest4 forwards error from observable")
+        subject.subscribe(onError: { _ in exp.fulfill() })
+        two.on(.error(TestError.test))
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCombineLatest4Error_fromThirdMember() {
+        let one = Observable<String>()
+        let two = Observable<Int>()
+        let three = Observable<Double>()
+        let four = Observable<String>()
+        let subject = Observable.combineLatest(one, two, three, four)
+
+        let exp = expectation(description: "combineLatest4 forwards error from observable")
+        subject.subscribe(onError: { _ in exp.fulfill() })
+        three.on(.error(TestError.test))
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCombineLatest4Error_fromFourthMember() {
         let one = Observable<String>()
         let two = Observable<Int>()
         let three = Observable<Double>()
@@ -637,7 +700,46 @@ class ObservableTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
-    func testCombineLatest4Done() {
+    func testCombineLatest4Done_fromFirstMember() {
+        let one = Observable<String>()
+        let two = Observable<Int>()
+        let three = Observable<Double>()
+        let four = Observable<String>()
+        let subject = Observable.combineLatest(one, two, three, four)
+
+        let exp = expectation(description: "combineLatest4 forwards done from observable")
+        subject.subscribe(onDone: { exp.fulfill() })
+        one.on(.done)
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCombineLatest4Done_fromSecondMember() {
+        let one = Observable<String>()
+        let two = Observable<Int>()
+        let three = Observable<Double>()
+        let four = Observable<String>()
+        let subject = Observable.combineLatest(one, two, three, four)
+
+        let exp = expectation(description: "combineLatest4 forwards done from observable")
+        subject.subscribe(onDone: { exp.fulfill() })
+        two.on(.done)
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCombineLatest4Done_fromThirdMember() {
+        let one = Observable<String>()
+        let two = Observable<Int>()
+        let three = Observable<Double>()
+        let four = Observable<String>()
+        let subject = Observable.combineLatest(one, two, three, four)
+
+        let exp = expectation(description: "combineLatest4 forwards done from observable")
+        subject.subscribe(onDone: { exp.fulfill() })
+        three.on(.done)
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCombineLatest4Done_fromFourthMember() {
         let one = Observable<String>()
         let two = Observable<Int>()
         let three = Observable<Double>()

--- a/SnailTests/ObservableTests.swift
+++ b/SnailTests/ObservableTests.swift
@@ -167,43 +167,68 @@ class ObservableTests: XCTestCase {
     }
 
     func testBlockSuccess() {
-        let result = Just(1).block()
-        XCTAssertEqual(result.result, 1)
-        XCTAssertNil(result.error)
+        let blockResult = Just(1).block()
+
+        guard case let .success(result) = blockResult else {
+            XCTFail("expected success")
+            return
+        }
+
+        XCTAssertEqual(result, 1)
     }
 
     func testBlockFail() {
-        let result = Fail<Void>(TestError.test).block()
-        XCTAssertNil(result.result)
-        XCTAssertNotNil(result.error)
+        let blockResult = Fail<Void>(TestError.test).block()
+        guard case let .failure(result) = blockResult else {
+            XCTFail("expected failure")
+            return
+        }
+
+        XCTAssertTrue(result is TestError)
     }
 
     func testBlockDone() {
         let observable = Observable<String>()
         observable.on(.done)
-        let result = observable.block()
-        XCTAssertNil(result.result)
-        XCTAssertNil(result.error)
+        let blockResult = observable.block()
+        guard case let .success(result) = blockResult else {
+            XCTFail("expected success")
+            return
+        }
+
+        XCTAssertEqual(result, nil)
     }
 
     func testBlockWithTimeoutSuccess() {
-        let result = Just(1).block(timeout: 1)
-        XCTAssertEqual(result.result, 1)
-        XCTAssertNil(result.error)
+        let blockResult = Just(1).block(timeout: 1)
+        guard case let .success(result) = blockResult else {
+            XCTFail("expected success")
+            return
+        }
+
+        XCTAssertEqual(result, 1)
     }
 
     func testBlockWithTimeoutFail() {
-        let result = Fail<Void>(TestError.test).block(timeout: 1)
-        XCTAssertNil(result.result)
-        XCTAssertNotNil(result.error)
+        let blockResult = Fail<Void>(TestError.test).block(timeout: 1)
+        guard case let .failure(result) = blockResult else {
+            XCTFail("expected failure")
+            return
+        }
+
+        XCTAssertTrue(result is TestError)
     }
 
     func testBlockWithTimeoutDone() {
         let observable = Observable<String>()
         observable.on(.done)
-        let result = observable.block(timeout: 1)
-        XCTAssertNil(result.result)
-        XCTAssertNil(result.error)
+        let blockResult = observable.block(timeout: 1)
+        guard case let .success(result) = blockResult else {
+            XCTFail("expected success")
+            return
+        }
+
+        XCTAssertEqual(result, nil)
     }
 
     func testThrottle() {


### PR DESCRIPTION
This PR aims to add some needed functionality to Snail. As well as cleans up some of the API.

Currently Observable type doesn't support, mapping, filtering or creating other observables.

This PR adds:

- `map` function to `Observable`
- `filter`﻿function to `Observable`
- `flatMap` function to `Observable`
- Adds `combineLatest` for 3 and 4 observables.
- Adds a `timeout` option to `block` function.
- Tests for the above

Note: 

- This is a breaking API change to `combineLatest` since I removed the tuple requirement from the function call.
- This is a breaking API change to `Variable.map` since I made `transform` argument parameter not required. 