### PR TITLE
Add take(first:) operator to Observable

### DIFF
--- a/Snail/Observable.swift
+++ b/Snail/Observable.swift
@@ -237,6 +237,28 @@ public class Observable<T>: ObservableType {
         return observable
     }
 
+    public func take(first count: UInt) -> Observable<T> {
+        let observable = Observable<T>()
+        var taken = 0
+
+        subscribe(onNext: {
+            if taken < count {
+                observable.on(.next($0))
+                taken += 1
+            }
+
+            if taken == count {
+                observable.on(.done)
+            }
+        }, onError: {
+            observable.on(.error($0))
+        }, onDone: {
+            observable.on(.done)
+        })
+
+        return observable
+    }
+
     func notify(subscriber: Subscriber<T>, event: Event<T>) {
         guard let queue = subscriber.queue else {
             subscriber.handler(event)

--- a/SnailTests/ObservableTests.swift
+++ b/SnailTests/ObservableTests.swift
@@ -343,6 +343,50 @@ class ObservableTests: XCTestCase {
         XCTAssertEqual(done, true)
     }
 
+    func testTakeFirst() {
+        let observable = Observable<String>()
+        var received: [String] = []
+
+        observable.take(first: 2).subscribe(onNext: { received.append($0) })
+
+        observable.on(.next("1"))
+        observable.on(.next("2"))
+        observable.on(.next("3"))
+
+        XCTAssertEqual(received, ["1", "2"])
+    }
+
+    func testTakeError() {
+        let observable = Observable<String>()
+
+        var error: TestError?
+        observable.take(first: 2).subscribe(onError: { error = $0 as? TestError })
+        observable.on(.error(TestError.test))
+
+        XCTAssertEqual(error, .test)
+    }
+
+    func testTakeDone() {
+        let observable = Observable<String>()
+        var done = false
+
+        observable.take(first: 2).subscribe(onDone: { done = true })
+        observable.on(.done)
+
+        XCTAssertEqual(done, true)
+    }
+
+    func testTakeDoneWhenCountIsReached() {
+        let observable = Observable<String>()
+        var done = false
+
+        observable.take(first: 2).subscribe(onDone: { done = true })
+        observable.on(.next("1"))
+        observable.on(.next("2"))
+
+        XCTAssertEqual(done, true)
+    }
+
     func testForward() {
         var received: [String] = []
         var receivedError: TestError?


### PR DESCRIPTION
Adds a `observable.take(first: n)` operator which allows only receiving up to `n` values from an observable stream.