### PR TITLE
Add thread safety to Observable & Replay

### DIFF
--- a/Snail.xcodeproj/xcshareddata/xcschemes/SnailTests.xcscheme
+++ b/Snail.xcodeproj/xcshareddata/xcschemes/SnailTests.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1170"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CBE54E491DFB36DF0008DD64"
+               BuildableName = "SnailTests.xctest"
+               BlueprintName = "SnailTests"
+               ReferencedContainer = "container:Snail.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CBE54E491DFB36DF0008DD64"
+               BuildableName = "SnailTests.xctest"
+               BlueprintName = "SnailTests"
+               ReferencedContainer = "container:Snail.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CBE54E491DFB36DF0008DD64"
+            BuildableName = "SnailTests.xctest"
+            BlueprintName = "SnailTests"
+            ReferencedContainer = "container:Snail.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SnailTests/ObservableTests.swift
+++ b/SnailTests/ObservableTests.swift
@@ -889,4 +889,17 @@ class ObservableTests: XCTestCase {
 
         waitForExpectations(timeout: 1)
     }
+
+    func testObservableDataRace() {
+        let subject = Observable<String>()
+        DispatchQueue.global().async {
+            subject.on(.next("global - async"))
+        }
+
+        subject.on(.next("sync"))
+
+        DispatchQueue.main.async {
+            subject.on(.next("main - async"))
+        }
+    }
 }

--- a/SnailTests/ReplayTests.swift
+++ b/SnailTests/ReplayTests.swift
@@ -78,4 +78,17 @@ class ReplayTests: XCTestCase {
             XCTAssertEqual(isMainQueue, true)
         }
     }
+
+    func testReplayDataRace() {
+        let subject = Replay<String>(1)
+        DispatchQueue.global().async {
+            subject.on(.next("global - async"))
+        }
+
+        subject.on(.next("sync"))
+
+        DispatchQueue.main.async {
+            subject.on(.next("main - async"))
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Both `Observable` and `Replay` have issues regarding data races when accessing `events` and `subscribers` arrays.

In this PR we are adding a dedicated queue for accessing these arrays. 

We use `sync` when reading the values from the array and use `async` with a barrier (which guarantees to wait for the last access to finish before a new access).

I've also added two new tests which both previously fail when running with thread sanitizer but pass now with these changes.
