### PR TITLE
Add zip operator

### DIFF
--- a/Snail/Observable.swift
+++ b/Snail/Observable.swift
@@ -464,42 +464,35 @@ public class Observable<T>: ObservableType {
     public static func zip<U>(_ input1: Observable<T>, _ input2: Observable<U>) -> Observable<(T, U)> {
         let combined = Observable<(T, U)>()
 
-        var input1Result: (value: [T], isComplete: Bool) = ([], false)
-        var input2Result: (value: [U], isComplete: Bool) = ([], false)
+        var input1Result: [T] = []
+        var input2Result: [U] = []
 
         func triggerIfNeeded() {
-            guard let value1 = input1Result.value.first,
-                  let value2 = input2Result.value.first else {
+            guard let value1 = input1Result.first,
+                  let value2 = input2Result.first else {
                 return
             }
-            input1Result.value.removeFirst()
-            input2Result.value.removeFirst()
+            input1Result.removeFirst()
+            input2Result.removeFirst()
             combined.on(.next((value1, value2)))
         }
 
-        func finishIfNeeded() {
-            guard input1Result.isComplete || input2Result.isComplete else { return }
-            combined.on(.done)
-        }
-
         input1.subscribe(onNext: {
-            input1Result.value.append($0)
+            input1Result.append($0)
             triggerIfNeeded()
         }, onError: {
             combined.on(.error($0))
         }, onDone: {
-            input1Result.isComplete = true
-            finishIfNeeded()
+            combined.on(.done)
         })
 
         input2.subscribe(onNext: {
-            input2Result.value.append($0)
+            input2Result.append($0)
             triggerIfNeeded()
         }, onError: {
             combined.on(.error($0))
         }, onDone: {
-            input2Result.isComplete = true
-            finishIfNeeded()
+            combined.on(.done)
         })
 
         return combined


### PR DESCRIPTION
### Summary
- Adding `Observable.zip(...)` operator, which is very similar to `Observable.combineLatest(...)`
- http://reactivex.io/documentation/operators/zip.html
- The `Zip` method returns an Observable that applies a function of your choosing to the combination of items emitted, in sequence, by two (or more) other Observables, with the results of this function becoming the items emitted by the returned Observable. It applies this function in strict sequence, so the first item emitted by the new Observable will be the result of the function applied to the first item emitted by Observable #1 and the first item emitted by Observable #2; the second item emitted by the new zip-Observable will be the result of the function applied to the second item emitted by Observable #1 and the second item emitted by Observable #2; and so forth. It will only emit as many items as the number of items emitted by the source Observable that emits the fewest items.
- Only adding for two observables at this time for simplicity. If we want more (similar to `.combineLatest`), let's wait for that use case to reduce complexity in the implementations.
