### PR TITLE
Update podspce file, change deployment target to ios 8

### DIFF
--- a/Snail.podspec
+++ b/Snail.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/UrbanCompass/Snail"
   s.license      = "MIT"
   s.author       = "Compass"
-  s.ios.deployment_target = "11.0"
+  s.ios.deployment_target = "8.0"
   s.source       = { :git => "https://github.com/UrbanCompass/Snail.git", :tag => "#{s.version}" }
   s.source_files  = "Snail/**/*.swift"
   s.swift_version = '5.0'


### PR DESCRIPTION
I noticed top closed PR that shows "Don't commit the podspec", but sorry to say our app still supports iOS system earlier than 11, and I see that Snail supports iOS 8+ actally, so could we change deployment target to iOS 8?