### PR TITLE
ObservableType (Snail) -> Publisher (Combine)

### DIFF
--- a/Snail.xcodeproj/project.pbxproj
+++ b/Snail.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		2E53BE0F2652D4E50030B9FB /* ReplayAsPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E53BE0E2652D4E50030B9FB /* ReplayAsPublisherTests.swift */; };
 		2E53BE112652D7370030B9FB /* UniqueAsPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E53BE102652D7370030B9FB /* UniqueAsPublisherTests.swift */; };
 		2E53BE132652D8B80030B9FB /* VariableAsPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E53BE122652D8B80030B9FB /* VariableAsPublisherTests.swift */; };
+		2E53BE512654717B0030B9FB /* SnailPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E53BE502654717B0030B9FB /* SnailPublisher.swift */; };
 		CB2936771DFE151B00792E6B /* Just.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2936761DFE151B00792E6B /* Just.swift */; };
 		CB2936791DFEF77500792E6B /* JustTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2936781DFEF77500792E6B /* JustTests.swift */; };
 		CBE54A7A1E5A16AC00971F74 /* Subscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE54A791E5A16AC00971F74 /* Subscriber.swift */; };
@@ -77,6 +78,7 @@
 		2E53BE0E2652D4E50030B9FB /* ReplayAsPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplayAsPublisherTests.swift; sourceTree = "<group>"; };
 		2E53BE102652D7370030B9FB /* UniqueAsPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniqueAsPublisherTests.swift; sourceTree = "<group>"; };
 		2E53BE122652D8B80030B9FB /* VariableAsPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariableAsPublisherTests.swift; sourceTree = "<group>"; };
+		2E53BE502654717B0030B9FB /* SnailPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnailPublisher.swift; sourceTree = "<group>"; };
 		CB2936761DFE151B00792E6B /* Just.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Just.swift; sourceTree = "<group>"; };
 		CB2936781DFEF77500792E6B /* JustTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JustTests.swift; sourceTree = "<group>"; };
 		CBE54A791E5A16AC00971F74 /* Subscriber.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Subscriber.swift; sourceTree = "<group>"; };
@@ -136,6 +138,7 @@
 				2E53BDEB264ECC940030B9FB /* Observable+Combine.swift */,
 				2E53BDED264ED4C70030B9FB /* SnailSubscription.swift */,
 				2E53BE082652B6D60030B9FB /* DemandBuffer.swift */,
+				2E53BE502654717B0030B9FB /* SnailPublisher.swift */,
 			);
 			path = "Snail+Combine";
 			sourceTree = "<group>";
@@ -371,6 +374,7 @@
 				24CF1FA81EF875A400F34234 /* URLSessionExtensions.swift in Sources */,
 				2E53BE092652B6D60030B9FB /* DemandBuffer.swift in Sources */,
 				2408FA902112A15900B9F59E /* Scheduler.swift in Sources */,
+				2E53BE512654717B0030B9FB /* SnailPublisher.swift in Sources */,
 				CBE54E601DFB39510008DD64 /* Event.swift in Sources */,
 				2E53BDEE264ED4C70030B9FB /* SnailSubscription.swift in Sources */,
 				F5C973A622F20C86003DB42C /* Disposer.swift in Sources */,

--- a/Snail.xcodeproj/project.pbxproj
+++ b/Snail.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		24FABD5C1DFF0BAF005CF84E /* ReplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24FABD5B1DFF0BAF005CF84E /* ReplayTests.swift */; };
 		2E53BDEC264ECC940030B9FB /* Observable+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E53BDEB264ECC940030B9FB /* Observable+Combine.swift */; };
 		2E53BDEE264ED4C70030B9FB /* SnailSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E53BDED264ED4C70030B9FB /* SnailSubscription.swift */; };
+		2E53BE072651F2990030B9FB /* ObservableAsPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E53BE062651F2990030B9FB /* ObservableAsPublisherTests.swift */; };
 		CB2936771DFE151B00792E6B /* Just.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2936761DFE151B00792E6B /* Just.swift */; };
 		CB2936791DFEF77500792E6B /* JustTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2936781DFEF77500792E6B /* JustTests.swift */; };
 		CBE54A7A1E5A16AC00971F74 /* Subscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE54A791E5A16AC00971F74 /* Subscriber.swift */; };
@@ -63,6 +64,7 @@
 		24FABD5B1DFF0BAF005CF84E /* ReplayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReplayTests.swift; sourceTree = "<group>"; };
 		2E53BDEB264ECC940030B9FB /* Observable+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Observable+Combine.swift"; sourceTree = "<group>"; };
 		2E53BDED264ED4C70030B9FB /* SnailSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnailSubscription.swift; sourceTree = "<group>"; };
+		2E53BE062651F2990030B9FB /* ObservableAsPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableAsPublisherTests.swift; sourceTree = "<group>"; };
 		CB2936761DFE151B00792E6B /* Just.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Just.swift; sourceTree = "<group>"; };
 		CB2936781DFEF77500792E6B /* JustTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JustTests.swift; sourceTree = "<group>"; };
 		CBE54A791E5A16AC00971F74 /* Subscriber.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Subscriber.swift; sourceTree = "<group>"; };
@@ -125,6 +127,14 @@
 			path = "Snail+Combine";
 			sourceTree = "<group>";
 		};
+		2E53BE052651F2710030B9FB /* Combine */ = {
+			isa = PBXGroup;
+			children = (
+				2E53BE062651F2990030B9FB /* ObservableAsPublisherTests.swift */,
+			);
+			path = Combine;
+			sourceTree = "<group>";
+		};
 		CBE54E371DFB36DF0008DD64 = {
 			isa = PBXGroup;
 			children = (
@@ -169,6 +179,7 @@
 		CBE54E4E1DFB36DF0008DD64 /* SnailTests */ = {
 			isa = PBXGroup;
 			children = (
+				2E53BE052651F2710030B9FB /* Combine */,
 				CBE54E511DFB36DF0008DD64 /* Info.plist */,
 				F5695389232046AA00D35C80 /* ClosureTests.swift */,
 				F5C973A722F4B359003DB42C /* DisposerTests.swift */,
@@ -362,6 +373,7 @@
 				24FABD5C1DFF0BAF005CF84E /* ReplayTests.swift in Sources */,
 				DEF9B98D1FD5D8FD00F8514E /* UniqueTests.swift in Sources */,
 				F569538A232046AA00D35C80 /* ClosureTests.swift in Sources */,
+				2E53BE072651F2990030B9FB /* ObservableAsPublisherTests.swift in Sources */,
 				CBE54E671DFB4F3F0008DD64 /* VariableTests.swift in Sources */,
 				24FABD581DFEF7EC005CF84E /* FailTests.swift in Sources */,
 				DEEDA8EB2051BCB4000FE578 /* NotificationCenterExtensions.swift in Sources */,

--- a/Snail.xcodeproj/project.pbxproj
+++ b/Snail.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		24FABD581DFEF7EC005CF84E /* FailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24FABD571DFEF7EC005CF84E /* FailTests.swift */; };
 		24FABD5A1DFF0B48005CF84E /* Replay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24FABD591DFF0B48005CF84E /* Replay.swift */; };
 		24FABD5C1DFF0BAF005CF84E /* ReplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24FABD5B1DFF0BAF005CF84E /* ReplayTests.swift */; };
+		2E53BDEC264ECC940030B9FB /* Observable+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E53BDEB264ECC940030B9FB /* Observable+Combine.swift */; };
+		2E53BDEE264ED4C70030B9FB /* SnailSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E53BDED264ED4C70030B9FB /* SnailSubscription.swift */; };
 		CB2936771DFE151B00792E6B /* Just.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2936761DFE151B00792E6B /* Just.swift */; };
 		CB2936791DFEF77500792E6B /* JustTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2936781DFEF77500792E6B /* JustTests.swift */; };
 		CBE54A7A1E5A16AC00971F74 /* Subscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE54A791E5A16AC00971F74 /* Subscriber.swift */; };
@@ -59,6 +61,8 @@
 		24FABD571DFEF7EC005CF84E /* FailTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FailTests.swift; sourceTree = "<group>"; };
 		24FABD591DFF0B48005CF84E /* Replay.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Replay.swift; sourceTree = "<group>"; };
 		24FABD5B1DFF0BAF005CF84E /* ReplayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReplayTests.swift; sourceTree = "<group>"; };
+		2E53BDEB264ECC940030B9FB /* Observable+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Observable+Combine.swift"; sourceTree = "<group>"; };
+		2E53BDED264ED4C70030B9FB /* SnailSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnailSubscription.swift; sourceTree = "<group>"; };
 		CB2936761DFE151B00792E6B /* Just.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Just.swift; sourceTree = "<group>"; };
 		CB2936781DFEF77500792E6B /* JustTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JustTests.swift; sourceTree = "<group>"; };
 		CBE54A791E5A16AC00971F74 /* Subscriber.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Subscriber.swift; sourceTree = "<group>"; };
@@ -112,6 +116,15 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
+		2E53BDEA264ECC770030B9FB /* Snail+Combine */ = {
+			isa = PBXGroup;
+			children = (
+				2E53BDEB264ECC940030B9FB /* Observable+Combine.swift */,
+				2E53BDED264ED4C70030B9FB /* SnailSubscription.swift */,
+			);
+			path = "Snail+Combine";
+			sourceTree = "<group>";
+		};
 		CBE54E371DFB36DF0008DD64 = {
 			isa = PBXGroup;
 			children = (
@@ -133,6 +146,7 @@
 		CBE54E431DFB36DF0008DD64 /* Snail */ = {
 			isa = PBXGroup;
 			children = (
+				2E53BDEA264ECC770030B9FB /* Snail+Combine */,
 				F569538B2320476100D35C80 /* Closure.swift */,
 				CBE54E441DFB36DF0008DD64 /* Snail.h */,
 				CBE54E451DFB36DF0008DD64 /* Info.plist */,
@@ -314,6 +328,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2E53BDEC264ECC940030B9FB /* Observable+Combine.swift in Sources */,
 				CBE54E621DFB39510008DD64 /* ObservableType.swift in Sources */,
 				CBE54A7A1E5A16AC00971F74 /* Subscriber.swift in Sources */,
 				2421BA721E09801000EA9064 /* UIGestureRecognizerExtensions.swift in Sources */,
@@ -327,6 +342,7 @@
 				24CF1FA81EF875A400F34234 /* URLSessionExtensions.swift in Sources */,
 				2408FA902112A15900B9F59E /* Scheduler.swift in Sources */,
 				CBE54E601DFB39510008DD64 /* Event.swift in Sources */,
+				2E53BDEE264ED4C70030B9FB /* SnailSubscription.swift in Sources */,
 				F5C973A622F20C86003DB42C /* Disposer.swift in Sources */,
 				CBE54E631DFB39510008DD64 /* Variable.swift in Sources */,
 				CBE54E6D1DFB6A910008DD64 /* UIControlExtensions.swift in Sources */,

--- a/Snail.xcodeproj/project.pbxproj
+++ b/Snail.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		2E53BDEC264ECC940030B9FB /* Observable+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E53BDEB264ECC940030B9FB /* Observable+Combine.swift */; };
 		2E53BDEE264ED4C70030B9FB /* SnailSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E53BDED264ED4C70030B9FB /* SnailSubscription.swift */; };
 		2E53BE072651F2990030B9FB /* ObservableAsPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E53BE062651F2990030B9FB /* ObservableAsPublisherTests.swift */; };
+		2E53BE092652B6D60030B9FB /* DemandBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E53BE082652B6D60030B9FB /* DemandBuffer.swift */; };
 		CB2936771DFE151B00792E6B /* Just.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2936761DFE151B00792E6B /* Just.swift */; };
 		CB2936791DFEF77500792E6B /* JustTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2936781DFEF77500792E6B /* JustTests.swift */; };
 		CBE54A7A1E5A16AC00971F74 /* Subscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE54A791E5A16AC00971F74 /* Subscriber.swift */; };
@@ -65,6 +66,7 @@
 		2E53BDEB264ECC940030B9FB /* Observable+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Observable+Combine.swift"; sourceTree = "<group>"; };
 		2E53BDED264ED4C70030B9FB /* SnailSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnailSubscription.swift; sourceTree = "<group>"; };
 		2E53BE062651F2990030B9FB /* ObservableAsPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableAsPublisherTests.swift; sourceTree = "<group>"; };
+		2E53BE082652B6D60030B9FB /* DemandBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemandBuffer.swift; sourceTree = "<group>"; };
 		CB2936761DFE151B00792E6B /* Just.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Just.swift; sourceTree = "<group>"; };
 		CB2936781DFEF77500792E6B /* JustTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JustTests.swift; sourceTree = "<group>"; };
 		CBE54A791E5A16AC00971F74 /* Subscriber.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Subscriber.swift; sourceTree = "<group>"; };
@@ -123,6 +125,7 @@
 			children = (
 				2E53BDEB264ECC940030B9FB /* Observable+Combine.swift */,
 				2E53BDED264ED4C70030B9FB /* SnailSubscription.swift */,
+				2E53BE082652B6D60030B9FB /* DemandBuffer.swift */,
 			);
 			path = "Snail+Combine";
 			sourceTree = "<group>";
@@ -351,6 +354,7 @@
 				CB2936771DFE151B00792E6B /* Just.swift in Sources */,
 				241F15581E03124600DD70A2 /* UIBarButtonItemExtensions.swift in Sources */,
 				24CF1FA81EF875A400F34234 /* URLSessionExtensions.swift in Sources */,
+				2E53BE092652B6D60030B9FB /* DemandBuffer.swift in Sources */,
 				2408FA902112A15900B9F59E /* Scheduler.swift in Sources */,
 				CBE54E601DFB39510008DD64 /* Event.swift in Sources */,
 				2E53BDEE264ED4C70030B9FB /* SnailSubscription.swift in Sources */,

--- a/Snail.xcodeproj/project.pbxproj
+++ b/Snail.xcodeproj/project.pbxproj
@@ -20,6 +20,11 @@
 		2E53BDEE264ED4C70030B9FB /* SnailSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E53BDED264ED4C70030B9FB /* SnailSubscription.swift */; };
 		2E53BE072651F2990030B9FB /* ObservableAsPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E53BE062651F2990030B9FB /* ObservableAsPublisherTests.swift */; };
 		2E53BE092652B6D60030B9FB /* DemandBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E53BE082652B6D60030B9FB /* DemandBuffer.swift */; };
+		2E53BE0B2652D0960030B9FB /* FailAsPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E53BE0A2652D0960030B9FB /* FailAsPublisherTests.swift */; };
+		2E53BE0D2652D37D0030B9FB /* JustAsPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E53BE0C2652D37D0030B9FB /* JustAsPublisherTests.swift */; };
+		2E53BE0F2652D4E50030B9FB /* ReplayAsPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E53BE0E2652D4E50030B9FB /* ReplayAsPublisherTests.swift */; };
+		2E53BE112652D7370030B9FB /* UniqueAsPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E53BE102652D7370030B9FB /* UniqueAsPublisherTests.swift */; };
+		2E53BE132652D8B80030B9FB /* VariableAsPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E53BE122652D8B80030B9FB /* VariableAsPublisherTests.swift */; };
 		CB2936771DFE151B00792E6B /* Just.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2936761DFE151B00792E6B /* Just.swift */; };
 		CB2936791DFEF77500792E6B /* JustTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2936781DFEF77500792E6B /* JustTests.swift */; };
 		CBE54A7A1E5A16AC00971F74 /* Subscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE54A791E5A16AC00971F74 /* Subscriber.swift */; };
@@ -67,6 +72,11 @@
 		2E53BDED264ED4C70030B9FB /* SnailSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnailSubscription.swift; sourceTree = "<group>"; };
 		2E53BE062651F2990030B9FB /* ObservableAsPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableAsPublisherTests.swift; sourceTree = "<group>"; };
 		2E53BE082652B6D60030B9FB /* DemandBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemandBuffer.swift; sourceTree = "<group>"; };
+		2E53BE0A2652D0960030B9FB /* FailAsPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailAsPublisherTests.swift; sourceTree = "<group>"; };
+		2E53BE0C2652D37D0030B9FB /* JustAsPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustAsPublisherTests.swift; sourceTree = "<group>"; };
+		2E53BE0E2652D4E50030B9FB /* ReplayAsPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplayAsPublisherTests.swift; sourceTree = "<group>"; };
+		2E53BE102652D7370030B9FB /* UniqueAsPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniqueAsPublisherTests.swift; sourceTree = "<group>"; };
+		2E53BE122652D8B80030B9FB /* VariableAsPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariableAsPublisherTests.swift; sourceTree = "<group>"; };
 		CB2936761DFE151B00792E6B /* Just.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Just.swift; sourceTree = "<group>"; };
 		CB2936781DFEF77500792E6B /* JustTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JustTests.swift; sourceTree = "<group>"; };
 		CBE54A791E5A16AC00971F74 /* Subscriber.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Subscriber.swift; sourceTree = "<group>"; };
@@ -134,6 +144,11 @@
 			isa = PBXGroup;
 			children = (
 				2E53BE062651F2990030B9FB /* ObservableAsPublisherTests.swift */,
+				2E53BE0A2652D0960030B9FB /* FailAsPublisherTests.swift */,
+				2E53BE0C2652D37D0030B9FB /* JustAsPublisherTests.swift */,
+				2E53BE0E2652D4E50030B9FB /* ReplayAsPublisherTests.swift */,
+				2E53BE102652D7370030B9FB /* UniqueAsPublisherTests.swift */,
+				2E53BE122652D8B80030B9FB /* VariableAsPublisherTests.swift */,
 			);
 			path = Combine;
 			sourceTree = "<group>";
@@ -372,12 +387,17 @@
 			buildActionMask = 2147483647;
 			files = (
 				CB2936791DFEF77500792E6B /* JustTests.swift in Sources */,
+				2E53BE132652D8B80030B9FB /* VariableAsPublisherTests.swift in Sources */,
+				2E53BE0F2652D4E50030B9FB /* ReplayAsPublisherTests.swift in Sources */,
 				CBE54E651DFB395A0008DD64 /* ObservableTests.swift in Sources */,
+				2E53BE0B2652D0960030B9FB /* FailAsPublisherTests.swift in Sources */,
 				F5C973A822F4B359003DB42C /* DisposerTests.swift in Sources */,
 				24FABD5C1DFF0BAF005CF84E /* ReplayTests.swift in Sources */,
 				DEF9B98D1FD5D8FD00F8514E /* UniqueTests.swift in Sources */,
+				2E53BE112652D7370030B9FB /* UniqueAsPublisherTests.swift in Sources */,
 				F569538A232046AA00D35C80 /* ClosureTests.swift in Sources */,
 				2E53BE072651F2990030B9FB /* ObservableAsPublisherTests.swift in Sources */,
+				2E53BE0D2652D37D0030B9FB /* JustAsPublisherTests.swift in Sources */,
 				CBE54E671DFB4F3F0008DD64 /* VariableTests.swift in Sources */,
 				24FABD581DFEF7EC005CF84E /* FailTests.swift in Sources */,
 				DEEDA8EB2051BCB4000FE578 /* NotificationCenterExtensions.swift in Sources */,

--- a/Snail/Snail+Combine/DemandBuffer.swift
+++ b/Snail/Snail+Combine/DemandBuffer.swift
@@ -1,0 +1,76 @@
+//  Copyright © 2021 Compass. All rights reserved.
+
+import Combine
+import Foundation
+
+@available(iOS 13.0, *)
+class DemandBuffer<S: Combine.Subscriber> {
+    private struct Demand {
+        var processed: Subscribers.Demand = .none
+        var requested: Subscribers.Demand = .none
+        var sent: Subscribers.Demand = .none
+    }
+
+    private let lock = NSRecursiveLock()
+    private var buffer: [S.Input] = []
+    private let subscriber: S
+    private var completion: Subscribers.Completion<S.Failure>?
+    private var demandState = Demand()
+
+    init(subscriber: S) {
+        self.subscriber = subscriber
+    }
+
+    func buffer(value: S.Input) -> Subscribers.Demand {
+        precondition(self.completion == nil,
+                     "Completed publisher should not be able to send values")
+
+        switch demandState.requested {
+        case .unlimited:
+            return subscriber.receive(value)
+        default:
+            buffer.append(value)
+            return flush()
+        }
+    }
+
+    func complete(completion: Subscribers.Completion<S.Failure>) {
+        precondition(self.completion == nil,
+                     "Completion should not be completed at this point")
+
+        self.completion = completion
+        _ = flush()
+    }
+
+    func demand(_ demand: Subscribers.Demand) -> Subscribers.Demand {
+        flush(adding: demand)
+    }
+
+    private func flush(adding newDemand: Subscribers.Demand? = nil) -> Subscribers.Demand {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let newDemand = newDemand {
+            demandState.requested += newDemand
+        }
+
+        guard demandState.requested > 0 || newDemand == Subscribers.Demand.none else { return .none }
+
+        while !buffer.isEmpty && demandState.processed < demandState.requested {
+            demandState.requested += subscriber.receive(buffer.remove(at: 0))
+            demandState.processed += 1
+        }
+
+        if let completion = completion {
+            buffer = []
+            demandState = .init()
+            self.completion = nil
+            subscriber.receive(completion: completion)
+            return .none
+        }
+
+        let sentDemand = demandState.requested - demandState.sent
+        demandState.sent += sentDemand
+        return sentDemand
+    }
+}

--- a/Snail/Snail+Combine/DemandBuffer.swift
+++ b/Snail/Snail+Combine/DemandBuffer.swift
@@ -8,6 +8,7 @@
 
 import Combine
 import Darwin
+import Foundation
 
 /// A buffer responsible for managing the demand of a downstream
 /// subscriber for an upstream publisher

--- a/Snail/Snail+Combine/Observable+Combine.swift
+++ b/Snail/Snail+Combine/Observable+Combine.swift
@@ -5,7 +5,7 @@ import Foundation
 
 @available(iOS 13.0, *)
 public extension ObservableType {
-    func asPublisher() -> AnyPublisher<T, Error> {
+    func asAnyPublisher() -> AnyPublisher<T, Error> {
         return SnailPublisher(upstream: self).eraseToAnyPublisher()
     }
 }

--- a/Snail/Snail+Combine/Observable+Combine.swift
+++ b/Snail/Snail+Combine/Observable+Combine.swift
@@ -5,28 +5,7 @@ import Foundation
 
 @available(iOS 13.0, *)
 public extension ObservableType {
-    var publisher: AnyPublisher<T, Error> {
-        return SnailPublisher(upstream: self).eraseToAnyPublisher()
-    }
-
     func asPublisher() -> AnyPublisher<T, Error> {
-        return publisher
-    }
-}
-
-@available(iOS 13.0, *)
-public class SnailPublisher<Upstream: ObservableType>: Publisher {
-    public typealias Output = Upstream.T
-    public typealias Failure = Swift.Error
-
-    private let upstream: Upstream
-
-    init(upstream: Upstream) {
-        self.upstream = upstream
-    }
-
-    public func receive<S: Combine.Subscriber>(subscriber: S) where Failure == S.Failure, Output == S.Input {
-        subscriber.receive(subscription: SnailSubscription(upstream: upstream,
-                                                           downstream: subscriber))
+        return SnailPublisher(upstream: self).eraseToAnyPublisher()
     }
 }

--- a/Snail/Snail+Combine/Observable+Combine.swift
+++ b/Snail/Snail+Combine/Observable+Combine.swift
@@ -1,0 +1,34 @@
+//  Copyright © 2021 Compass. All rights reserved.
+
+#if canImport(Combine)
+import Combine
+import Foundation
+
+@available(iOS 13.0, *)
+public extension ObservableType {
+    var publisher: AnyPublisher<T, Error> {
+        return SnailPublisher(upstream: self).eraseToAnyPublisher()
+    }
+
+    func asPublisher() -> AnyPublisher<T, Error> {
+        return publisher
+    }
+}
+
+@available(iOS 13.0, *)
+public class SnailPublisher<Upstream: ObservableType>: Publisher {
+    public typealias Output = Upstream.T
+    public typealias Failure = Swift.Error
+
+    private let upstream: Upstream
+
+    init(upstream: Upstream) {
+        self.upstream = upstream
+    }
+
+    public func receive<S: Combine.Subscriber>(subscriber: S) where Failure == S.Failure, Output == S.Input {
+        subscriber.receive(subscription: SnailSubscription(upstream: upstream,
+                                                           downstream: subscriber))
+    }
+}
+#endif

--- a/Snail/Snail+Combine/Observable+Combine.swift
+++ b/Snail/Snail+Combine/Observable+Combine.swift
@@ -1,6 +1,5 @@
 //  Copyright © 2021 Compass. All rights reserved.
 
-#if canImport(Combine)
 import Combine
 import Foundation
 
@@ -31,4 +30,3 @@ public class SnailPublisher<Upstream: ObservableType>: Publisher {
                                                            downstream: subscriber))
     }
 }
-#endif

--- a/Snail/Snail+Combine/SnailPublisher.swift
+++ b/Snail/Snail+Combine/SnailPublisher.swift
@@ -1,0 +1,21 @@
+//  Copyright © 2021 Compass. All rights reserved.
+
+import Combine
+import Foundation
+
+@available(iOS 13.0, *)
+public class SnailPublisher<Upstream: ObservableType>: Publisher {
+    public typealias Output = Upstream.T
+    public typealias Failure = Error
+
+    private let upstream: Upstream
+
+    init(upstream: Upstream) {
+        self.upstream = upstream
+    }
+
+    public func receive<S: Combine.Subscriber>(subscriber: S) where Failure == S.Failure, Output == S.Input {
+        subscriber.receive(subscription: SnailSubscription(upstream: upstream,
+                                                           downstream: subscriber))
+    }
+}

--- a/Snail/Snail+Combine/SnailSubscription.swift
+++ b/Snail/Snail+Combine/SnailSubscription.swift
@@ -1,0 +1,34 @@
+//  Copyright © 2021 Compass. All rights reserved.
+
+#if canImport(Combine)
+import Combine
+import Foundation
+
+@available(iOS 13.0, *)
+class SnailSubscription<Upstream: ObservableType, Downstream: Combine.Subscriber>: Combine.Subscription where Downstream.Input == Upstream.T, Downstream.Failure == Error {
+    private var disposable: Subscriber<Upstream.T>?
+
+    init(upstream: Upstream,
+         downstream: Downstream) {
+        disposable = upstream.subscribe(queue: nil,
+                                        onNext: { value in
+                                            _ = downstream.receive(value)
+                                        },
+                                        onError: { error in
+                                            downstream.receive(completion: .failure(error))
+                                        },
+                                        onDone: {
+                                            downstream.receive(completion: .finished)
+                                        })
+    }
+
+    func request(_ demand: Subscribers.Demand) {
+        // For now, not supporting changing any kind of demand
+    }
+
+    func cancel() {
+        disposable?.dispose()
+        disposable = nil
+    }
+}
+#endif

--- a/Snail/Snail+Combine/SnailSubscription.swift
+++ b/Snail/Snail+Combine/SnailSubscription.swift
@@ -15,7 +15,6 @@ class SnailSubscription<Upstream: ObservableType, Downstream: Combine.Subscriber
         disposable = upstream.subscribe(queue: nil,
                                         onNext: { [weak self] value in
                                             guard let self = self else { return }
-
                                             _ = self.buffer.buffer(value: value)
                                         },
                                         onError: { [weak self] error in

--- a/Snail/Snail+Combine/SnailSubscription.swift
+++ b/Snail/Snail+Combine/SnailSubscription.swift
@@ -1,6 +1,5 @@
 //  Copyright © 2021 Compass. All rights reserved.
 
-#if canImport(Combine)
 import Combine
 import Foundation
 
@@ -36,4 +35,3 @@ class SnailSubscription<Upstream: ObservableType, Downstream: Combine.Subscriber
         disposable = nil
     }
 }
-#endif

--- a/SnailTests/Combine/FailAsPublisherTests.swift
+++ b/SnailTests/Combine/FailAsPublisherTests.swift
@@ -32,7 +32,7 @@ class FailAsPublisherTests: XCTestCase {
     }
 
     func testOnErrorIsRun() {
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { [unowned self] completion in
                 if case let .failure(underlying) = completion {
                     self.error = underlying as? TestError
@@ -45,7 +45,7 @@ class FailAsPublisherTests: XCTestCase {
     }
 
     func testOnNextIsNotRun() {
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { [unowned self] in self.strings.append($0) })
             .store(in: &subscriptions)

--- a/SnailTests/Combine/FailAsPublisherTests.swift
+++ b/SnailTests/Combine/FailAsPublisherTests.swift
@@ -1,0 +1,53 @@
+//  Copyright © 2021 Compass. All rights reserved.
+
+import Combine
+import Foundation
+@testable import Snail
+import XCTest
+
+@available(iOS 13.0, *)
+class FailAsPublisherTests: XCTestCase {
+    enum TestError: Error {
+        case test
+    }
+
+    private var subject: Observable<String>!
+    private var strings: [String]!
+    private var error: Error?
+    private var subscription: AnyCancellable?
+
+    override func setUp() {
+        super.setUp()
+        subject = Fail(TestError.test)
+        strings = []
+        error = nil
+    }
+
+    override func tearDown() {
+        subject = nil
+        strings = nil
+        error = nil
+        subscription = nil
+    }
+
+    func testOnErrorIsRun() {
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { [unowned self] completion in
+                if case let .failure(underlying) = completion {
+                    self.error = underlying as? TestError
+                }
+            },
+            receiveValue: { _ in })
+
+        XCTAssertEqual((error as? TestError), TestError.test)
+    }
+
+    func testOnNextIsNotRun() {
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { [unowned self] in strings.append($0) })
+        subject?.on(.next("1"))
+
+        XCTAssertEqual(strings?.count, 0)
+    }
+}

--- a/SnailTests/Combine/JustAsPublisherTests.swift
+++ b/SnailTests/Combine/JustAsPublisherTests.swift
@@ -1,0 +1,31 @@
+//  Copyright © 2021 Compass. All rights reserved.
+
+import Combine
+import Foundation
+@testable import Snail
+import XCTest
+
+@available(iOS 13.0, *)
+class JustAsPublisherTests: XCTestCase {
+    private var subscription: AnyCancellable?
+
+    override func tearDown() {
+        subscription = nil
+        super.tearDown()
+    }
+
+    func testJust() {
+        var result: Int?
+        var done = false
+
+        subscription = Just(1).asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case .finished = completion {
+                    done = true
+                }
+            },
+            receiveValue: { result = $0 })
+        XCTAssertEqual(1, result)
+        XCTAssertTrue(done)
+    }
+}

--- a/SnailTests/Combine/JustAsPublisherTests.swift
+++ b/SnailTests/Combine/JustAsPublisherTests.swift
@@ -22,7 +22,7 @@ class JustAsPublisherTests: XCTestCase {
         var result: Int?
         var done = false
 
-        Just(1).asPublisher()
+        Just(1).asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case .finished = completion {
                     done = true

--- a/SnailTests/Combine/JustAsPublisherTests.swift
+++ b/SnailTests/Combine/JustAsPublisherTests.swift
@@ -7,10 +7,14 @@ import XCTest
 
 @available(iOS 13.0, *)
 class JustAsPublisherTests: XCTestCase {
-    private var subscription: AnyCancellable?
+    private var subscriptions: Set<AnyCancellable>!
+
+    override func setUp() {
+        subscriptions = Set<AnyCancellable>()
+    }
 
     override func tearDown() {
-        subscription = nil
+        subscriptions = nil
         super.tearDown()
     }
 
@@ -18,13 +22,15 @@ class JustAsPublisherTests: XCTestCase {
         var result: Int?
         var done = false
 
-        subscription = Just(1).asPublisher()
+        Just(1).asPublisher()
             .sink(receiveCompletion: { completion in
                 if case .finished = completion {
                     done = true
                 }
             },
             receiveValue: { result = $0 })
+            .store(in: &subscriptions)
+
         XCTAssertEqual(1, result)
         XCTAssertTrue(done)
     }

--- a/SnailTests/Combine/ObservableAsPublisherTests.swift
+++ b/SnailTests/Combine/ObservableAsPublisherTests.swift
@@ -42,7 +42,7 @@ class ObservableAsPublisherTests: XCTestCase {
     }
 
     func testNext() {
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { [unowned self] completion in
                 switch completion {
                 case .finished:
@@ -60,7 +60,7 @@ class ObservableAsPublisherTests: XCTestCase {
     }
 
     func testOnDone() {
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { [unowned self] completion in
                 switch completion {
                 case .finished:
@@ -84,7 +84,7 @@ class ObservableAsPublisherTests: XCTestCase {
     }
 
     func testOnError() {
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { [unowned self] completion in
                 switch completion {
                 case .finished:
@@ -111,7 +111,7 @@ class ObservableAsPublisherTests: XCTestCase {
         subject.subscribe(onNext: { string in
             more.append(string)
         }).add(to: disposer)
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { [unowned self] string in
                     self.strings?.append(string)
@@ -127,7 +127,7 @@ class ObservableAsPublisherTests: XCTestCase {
         subject?.on(.error(TestError.test))
 
         var oldError: TestError?
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case let .failure(underlying) = completion {
                     oldError = underlying as? TestError
@@ -143,7 +143,7 @@ class ObservableAsPublisherTests: XCTestCase {
         let exp = expectation(description: "queue")
 
         DispatchQueue.global().async {
-            self.subject.asPublisher()
+            self.subject.asAnyPublisher()
                 .receive(on: DispatchQueue.main)
                 .sink(receiveCompletion: { _ in },
                       receiveValue: { _ in
@@ -166,7 +166,7 @@ class ObservableAsPublisherTests: XCTestCase {
 
         DispatchQueue.global().async {
             self.subject.on(.main)
-                .asPublisher()
+                .asAnyPublisher()
                 .sink(receiveCompletion: { _ in },
                       receiveValue: { _ in
                         exp.fulfill()
@@ -187,7 +187,7 @@ class ObservableAsPublisherTests: XCTestCase {
         let exp = expectation(description: "queue")
 
         self.subject.on(.global())
-            .asPublisher()
+            .asAnyPublisher()
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { _ in },
                   receiveValue: { _ in
@@ -204,7 +204,7 @@ class ObservableAsPublisherTests: XCTestCase {
     }
 
     func testRemovingSubscribers() {
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { [unowned self] str in
                     self.strings.append(str)
@@ -223,7 +223,7 @@ class ObservableAsPublisherTests: XCTestCase {
             onError: { error in self.error = error },
             onDone: { self.done = true })
 
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { [unowned self] str in
                     self.strings.append(str)
@@ -261,7 +261,7 @@ class ObservableAsPublisherTests: XCTestCase {
         }
 
         observable.throttle(delay)
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { received.append($0) })
             .store(in: &subscriptions)
@@ -290,7 +290,7 @@ class ObservableAsPublisherTests: XCTestCase {
         }
 
         observable.throttle(delay)
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { received.append($0) })
             .store(in: &subscriptions)
@@ -322,7 +322,7 @@ class ObservableAsPublisherTests: XCTestCase {
         }
 
         observable.debounce(delay)
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { received.append($0) })
             .store(in: &subscriptions)
@@ -340,7 +340,7 @@ class ObservableAsPublisherTests: XCTestCase {
         var received: [String] = []
 
         observable.skip(first: 2)
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { received.append($0) })
             .store(in: &subscriptions)
@@ -357,7 +357,7 @@ class ObservableAsPublisherTests: XCTestCase {
 
         var error: TestError?
         observable.skip(first: 2)
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case let .failure(underlying) = completion {
                     error = underlying as? TestError
@@ -375,7 +375,7 @@ class ObservableAsPublisherTests: XCTestCase {
         var done = false
 
         observable.skip(first: 2)
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case .finished = completion {
                     done = true
@@ -394,7 +394,7 @@ class ObservableAsPublisherTests: XCTestCase {
         var received: [String] = []
 
         observable.take(first: 2)
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { received.append($0) })
             .store(in: &subscriptions)
@@ -411,7 +411,7 @@ class ObservableAsPublisherTests: XCTestCase {
 
         var error: TestError?
         observable.take(first: 2)
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case let .failure(underlying) = completion {
                     error = underlying as? TestError
@@ -430,7 +430,7 @@ class ObservableAsPublisherTests: XCTestCase {
         var done = false
 
         observable.take(first: 2)
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case .finished = completion {
                     done = true
@@ -449,7 +449,7 @@ class ObservableAsPublisherTests: XCTestCase {
         var done = false
 
         observable.take(first: 2)
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case .finished = completion {
                     done = true
@@ -472,7 +472,7 @@ class ObservableAsPublisherTests: XCTestCase {
         let observable = Observable<String>()
         observable.forward(to: subject)
 
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case let .failure(underlying) = completion {
                     receivedError = underlying as? TestError
@@ -496,7 +496,7 @@ class ObservableAsPublisherTests: XCTestCase {
         let observable = Observable<String>()
         observable.forward(to: subject)
 
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { received.append($0) })
             .store(in: &subscriptions)
@@ -516,7 +516,7 @@ class ObservableAsPublisherTests: XCTestCase {
 
         let subject = Observable.merge([a, b])
 
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { received.append($0) })
             .store(in: &subscriptions)
@@ -538,7 +538,7 @@ class ObservableAsPublisherTests: XCTestCase {
 
         let subject = Observable.merge(a, b)
 
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { received.append($0) })
             .store(in: &subscriptions)
@@ -560,7 +560,7 @@ class ObservableAsPublisherTests: XCTestCase {
 
         let subject = Observable.combineLatest(string, int)
 
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { string, int in
                     received.append(("\(string): \(int)"))
@@ -590,7 +590,7 @@ class ObservableAsPublisherTests: XCTestCase {
 
         let subject = Observable.combineLatest(string, int)
 
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { string, int in
                     received.append(("\(string ?? "<no title>"): \(int ?? 0)"))
@@ -620,7 +620,7 @@ class ObservableAsPublisherTests: XCTestCase {
 
         let subject = Observable.combineLatest(string, int)
 
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case .failure = completion {
                     received.append("ERROR")
@@ -652,7 +652,7 @@ class ObservableAsPublisherTests: XCTestCase {
 
         let subject = Observable.combineLatest(string, int)
 
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case .failure = completion {
                     received.append("ERROR")
@@ -674,7 +674,7 @@ class ObservableAsPublisherTests: XCTestCase {
 
         var isDone = false
         Observable.combineLatest(obs1, obs2)
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case .finished = completion {
                     isDone = true
@@ -698,7 +698,7 @@ class ObservableAsPublisherTests: XCTestCase {
         var received = [(String, Int, Double)]()
         let subject = Observable.combineLatest(one, two, three)
 
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { received.append($0) })
             .store(in: &subscriptions)
@@ -722,7 +722,7 @@ class ObservableAsPublisherTests: XCTestCase {
         let subject = Observable.combineLatest(one, two, three)
 
         let exp = expectation(description: "combineLatest3 forwards error from observable")
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case .failure = completion {
                     exp.fulfill()
@@ -741,7 +741,7 @@ class ObservableAsPublisherTests: XCTestCase {
         let subject = Observable.combineLatest(one, two, three)
 
         let exp = expectation(description: "combineLatest3 forwards error from observable")
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case .failure = completion {
                     exp.fulfill()
@@ -760,7 +760,7 @@ class ObservableAsPublisherTests: XCTestCase {
 
         var isDone = false
         Observable.combineLatest(obs1, obs2, obs3)
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case .finished = completion {
                     isDone = true
@@ -787,7 +787,7 @@ class ObservableAsPublisherTests: XCTestCase {
         var received = [(String, Int?, Double)]()
         let subject = Observable.combineLatest(one, two, three)
 
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { received.append($0) })
             .store(in: &subscriptions)
@@ -813,7 +813,7 @@ class ObservableAsPublisherTests: XCTestCase {
         var received = [(String, Int, Double, String)]()
         let subject = Observable.combineLatest(one, two, three, four)
 
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { received.append($0) })
             .store(in: &subscriptions)
@@ -842,7 +842,7 @@ class ObservableAsPublisherTests: XCTestCase {
         let subject = Observable.combineLatest(one, two, three, four)
 
         let exp = expectation(description: "combineLatest4 forwards error from observable")
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case .failure = completion {
                     exp.fulfill()
@@ -862,7 +862,7 @@ class ObservableAsPublisherTests: XCTestCase {
         let subject = Observable.combineLatest(one, two, three, four)
 
         let exp = expectation(description: "combineLatest4 forwards error from observable")
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case .failure = completion {
                     exp.fulfill()
@@ -882,7 +882,7 @@ class ObservableAsPublisherTests: XCTestCase {
         let subject = Observable.combineLatest(one, two, three, four)
 
         let exp = expectation(description: "combineLatest4 forwards error from observable")
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case .failure = completion {
                     exp.fulfill()
@@ -902,7 +902,7 @@ class ObservableAsPublisherTests: XCTestCase {
         let subject = Observable.combineLatest(one, two, three, four)
 
         let exp = expectation(description: "combineLatest4 forwards error from observable")
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case .failure = completion {
                     exp.fulfill()
@@ -922,7 +922,7 @@ class ObservableAsPublisherTests: XCTestCase {
 
         var isDone = false
         Observable.combineLatest(obs1, obs2, obs3, obs4)
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case .finished = completion {
                     isDone = true
@@ -953,7 +953,7 @@ class ObservableAsPublisherTests: XCTestCase {
         var received = [(String, Int?, Double, String?)]()
         let subject = Observable.combineLatest(one, two, three, four)
 
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { received.append($0) })
             .store(in: &subscriptions)
@@ -979,7 +979,7 @@ class ObservableAsPublisherTests: XCTestCase {
         let subject = observable.map { "Number: \($0)" }
         var received = [String]()
 
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { received.append($0) })
             .store(in: &subscriptions)
@@ -995,7 +995,7 @@ class ObservableAsPublisherTests: XCTestCase {
         let subject = observable.map { "Number: \($0)" }
 
         let exp = expectation(description: "observable map forwards error")
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case .failure = completion {
                     exp.fulfill()
@@ -1014,7 +1014,7 @@ class ObservableAsPublisherTests: XCTestCase {
         let subject = observable.map { "Number: \($0)" }
 
         let exp = expectation(description: "observable map forwards done")
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case .finished = completion {
                     exp.fulfill()
@@ -1033,7 +1033,7 @@ class ObservableAsPublisherTests: XCTestCase {
         let subject = observable.filter { $0 % 2 == 0 }
         var received = [Int]()
 
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { received.append($0) })
             .store(in: &subscriptions)
@@ -1051,7 +1051,7 @@ class ObservableAsPublisherTests: XCTestCase {
         let subject = observable.filter { $0 % 2 == 0 }
 
         let exp = expectation(description: "observable filter forwards error")
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case .failure = completion {
                     exp.fulfill()
@@ -1070,7 +1070,7 @@ class ObservableAsPublisherTests: XCTestCase {
         let subject = observable.filter { $0 % 2 == 0 }
 
         let exp = expectation(description: "observable filter forwards done")
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case .finished = completion {
                     exp.fulfill()
@@ -1089,7 +1089,7 @@ class ObservableAsPublisherTests: XCTestCase {
         let subject = fetchTrigger.flatMap { Variable(100).asObservable() }
         var received = [Int]()
 
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { received.append($0) })
             .store(in: &subscriptions)
@@ -1103,7 +1103,7 @@ class ObservableAsPublisherTests: XCTestCase {
         let subject = fetchTrigger.flatMap { Variable(100).asObservable() }
 
         let exp = expectation(description: "observable flatMap forwards error")
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case .failure = completion {
                     exp.fulfill()
@@ -1121,7 +1121,7 @@ class ObservableAsPublisherTests: XCTestCase {
         let subject = fetchTrigger.flatMap { Variable(100).asObservable() }
 
         let exp = expectation(description: "observable flatMap forwards done")
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case .finished = completion {
                     exp.fulfill()
@@ -1142,7 +1142,7 @@ class ObservableAsPublisherTests: XCTestCase {
 
         let subject = Observable.zip(string, int)
 
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { string, int in
                     received.append("\(string): \(int)")
@@ -1171,7 +1171,7 @@ class ObservableAsPublisherTests: XCTestCase {
 
         let subject = Observable.zip(string, int)
 
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { string, int in
                     received.append("\(string ?? "<no title>"): \(int ?? 0)")
@@ -1200,7 +1200,7 @@ class ObservableAsPublisherTests: XCTestCase {
 
         let subject = Observable.zip(string, int)
 
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { string, int in
                     received.append("\(string): \(int)")
@@ -1231,7 +1231,7 @@ class ObservableAsPublisherTests: XCTestCase {
         let subject = Observable.zip(one, two)
 
         let exp = expectation(description: "zip forwards error from observable")
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case .failure = completion {
                     exp.fulfill()
@@ -1250,7 +1250,7 @@ class ObservableAsPublisherTests: XCTestCase {
 
         var isDone = false
         Observable.zip(one, two)
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { completion in
                 if case .finished = completion {
                     isDone = true

--- a/SnailTests/Combine/ObservableAsPublisherTests.swift
+++ b/SnailTests/Combine/ObservableAsPublisherTests.swift
@@ -1262,4 +1262,27 @@ class ObservableAsPublisherTests: XCTestCase {
         one.on(.done)
         XCTAssertTrue(isDone)
     }
+
+    func testNoDeadLock() {
+        class TestObject {
+            let disposer = Disposer()
+
+            init(variable: Variable<Bool>) {
+                variable.asObservable().subscribe()
+                .add(to: disposer)
+            }
+        }
+
+        let subject = Variable(true)
+
+        subject.asObservable()
+            .asAnyPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { _ in
+                    _ = TestObject(variable: subject)
+            })
+            .store(in: &subscriptions)
+
+        subject.value = true
+    }
 }

--- a/SnailTests/Combine/ObservableAsPublisherTests.swift
+++ b/SnailTests/Combine/ObservableAsPublisherTests.swift
@@ -2,7 +2,6 @@
 
 // swiftlint:disable file_length
 
-#if canImport(Combine)
 import Combine
 import Foundation
 @testable import Snail
@@ -1129,4 +1128,3 @@ class ObservableAsPublisherTests: XCTestCase {
         XCTAssertTrue(isDone)
     }
 }
-#endif

--- a/SnailTests/Combine/ObservableAsPublisherTests.swift
+++ b/SnailTests/Combine/ObservableAsPublisherTests.swift
@@ -1,0 +1,1132 @@
+//  Copyright © 2021 Compass. All rights reserved.
+
+// swiftlint:disable file_length
+
+#if canImport(Combine)
+import Combine
+import Foundation
+@testable import Snail
+import XCTest
+
+@available(iOS 13.0, *)
+class ObservableAsPublisherTests: XCTestCase {
+    enum TestError: Error {
+        case test
+    }
+
+    private var subject: Observable<String>!
+    private var strings: [String]!
+    private var error: Error?
+    private var done: Bool?
+    private var disposer: Disposer!
+
+    private var subscription: AnyCancellable?
+
+    override func setUp() {
+        super.setUp()
+        subject = Observable()
+        strings = []
+        error = nil
+        done = nil
+        disposer = Disposer()
+    }
+
+    override func tearDown() {
+        subject = nil
+        strings = nil
+        error = nil
+        done = nil
+        disposer = nil
+        subscription = nil
+        super.tearDown()
+    }
+
+    func testNext() {
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { [unowned self] completion in
+                switch completion {
+                case .finished:
+                    self.done = true
+                case let .failure(underlyingError):
+                    self.error = underlyingError
+                }
+            },
+            receiveValue: { [unowned self] in self.strings?.append($0) })
+
+        ["1", "2"].forEach { subject?.on(.next($0)) }
+
+        XCTAssertEqual(strings, ["1", "2"])
+    }
+
+    func testOnDone() {
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { [unowned self] completion in
+                switch completion {
+                case .finished:
+                    self.done = true
+                case let .failure(underlyingError):
+                    self.error = underlyingError
+                }
+            },
+            receiveValue: { [unowned self] in self.strings?.append($0) })
+
+        subject?.on(.next("1"))
+        subject?.on(.next("2"))
+        subject?.on(.done)
+        subject?.on(.next("3"))
+
+        XCTAssertEqual(strings?.count, 2)
+        XCTAssertEqual(strings?[0], "1")
+        XCTAssertEqual(strings?[1], "2")
+        XCTAssertEqual(done, true)
+    }
+
+    func testOnError() {
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { [unowned self] completion in
+                switch completion {
+                case .finished:
+                    self.done = true
+                case let .failure(underlyingError):
+                    self.error = underlyingError
+                }
+            },
+            receiveValue: { [unowned self] in self.strings?.append($0) })
+
+        subject?.on(.next("1"))
+        subject?.on(.next("2"))
+        subject?.on(.error(TestError.test))
+        subject?.on(.next("3"))
+        XCTAssertEqual(strings?.count, 2)
+        XCTAssertEqual(strings?[0], "1")
+        XCTAssertEqual(strings?[1], "2")
+        XCTAssertEqual(error as? TestError, .test)
+    }
+
+    func testFiresStoppedEventOnSubscribeIfStopped() {
+        subject?.on(.error(TestError.test))
+
+        var oldError: TestError?
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case let .failure(underlying) = completion {
+                    oldError = underlying as? TestError
+                }
+            }, receiveValue: { _ in })
+        XCTAssertEqual(oldError, .test)
+    }
+
+    func testRemovingSubscribers() {
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { [unowned self] str in
+                    self.strings.append(str)
+            })
+        subject?.on(.next("1"))
+        subject?.removeSubscribers()
+        subject?.on(.next("2"))
+        XCTAssertEqual(strings?[0], "1")
+        XCTAssertEqual(strings?.count, 1)
+    }
+
+    func testRemoveSubscriber() {
+        let subscriberToRemove = subject?.subscribe(
+            onNext: { string in self.strings?.append(string) },
+            onError: { error in self.error = error },
+            onDone: { self.done = true })
+
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { [unowned self] str in
+                    self.strings.append(str)
+            })
+
+        subject?.on(.next("1"))
+        guard let subscriber = subscriberToRemove else {
+            return
+        }
+        subject?.removeSubscriber(subscriber: subscriber)
+        subject?.on(.next("2"))
+        XCTAssertEqual(strings?.count, 3)
+        XCTAssertEqual(strings?[0], "1")
+        XCTAssertEqual(strings?[1], "1")
+        XCTAssertEqual(strings?[2], "2")
+        subject?.removeSubscriber(subscriber: subscriber)
+        subject?.on(.next("3"))
+        XCTAssertEqual(strings?.count, 4)
+        XCTAssertEqual(strings?[0], "1")
+        XCTAssertEqual(strings?[1], "1")
+        XCTAssertEqual(strings?[2], "2")
+        XCTAssertEqual(strings?[3], "3")
+    }
+
+    func testThrottle() {
+        let observable = Observable<String>()
+        var received: [String] = []
+
+        let exp = expectation(description: "throttle")
+        let delay = 0.01
+
+        DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + delay) {
+            exp.fulfill()
+        }
+
+        subscription = observable.throttle(delay)
+            .asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { received.append($0) })
+
+        observable.on(.next("1"))
+        observable.on(.next("2"))
+        waitForExpectations(timeout: delay*2) { _ in
+            XCTAssertEqual(received.count, 1)
+            XCTAssertEqual(received.first, "2")
+        }
+    }
+
+    func testThrottleDelays() {
+        let observable = Observable<String>()
+        var received: [String] = []
+
+        let exp = expectation(description: "debounce")
+        let delay = 0.01
+
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + delay) {
+            observable.on(.next("2"))
+            observable.on(.next("3"))
+            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + delay) {
+                exp.fulfill()
+            }
+        }
+
+        subscription = observable.throttle(delay)
+            .asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { received.append($0) })
+
+        observable.on(.next("1"))
+
+        waitForExpectations(timeout: 1) { _ in
+            XCTAssertEqual(received.count, 2)
+            XCTAssertEqual(received.first, "1")
+            XCTAssertEqual(received.last, "3")
+        }
+    }
+
+    func testDebounce() {
+        let observable = Observable<String>()
+        var received: [String] = []
+
+        let exp = expectation(description: "debounce")
+        let delay = 0.02
+
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + delay/2) {
+            observable.on(.next("2"))
+            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + delay/2) {
+                observable.on(.next("3"))
+                DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + delay) {
+                    exp.fulfill()
+                }
+            }
+        }
+
+        subscription = observable.debounce(delay)
+            .asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { received.append($0) })
+
+        observable.on(.next("1"))
+
+        waitForExpectations(timeout: 1) { _ in
+            XCTAssertEqual(received.count, 1)
+            XCTAssertEqual(received.first, "3")
+        }
+    }
+
+    func testSkipFirst() {
+        let observable = Observable<String>()
+        var received: [String] = []
+
+        subscription = observable.skip(first: 2)
+            .asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { received.append($0) })
+
+        observable.on(.next("1"))
+        observable.on(.next("2"))
+        observable.on(.next("3"))
+        XCTAssertEqual(received.count, 1)
+        XCTAssertEqual(received.first, "3")
+    }
+
+    func testSkipError() {
+        let observable = Observable<String>()
+
+        var error: TestError?
+        subscription = observable.skip(first: 2)
+            .asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case let .failure(underlying) = completion {
+                    error = underlying as? TestError
+                }
+            },
+            receiveValue: { _ in })
+        observable.on(.error(TestError.test))
+
+        XCTAssertEqual(error, .test)
+    }
+
+    func testSkipDone() {
+        let observable = Observable<String>()
+        var done = false
+
+        subscription = observable.skip(first: 2)
+            .asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case .finished = completion {
+                    done = true
+                }
+            },
+            receiveValue: { _ in })
+
+        observable.on(.done)
+
+        XCTAssertEqual(done, true)
+    }
+
+    func testTakeFirst() {
+        let observable = Observable<String>()
+        var received: [String] = []
+
+        subscription = observable.take(first: 2)
+            .asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { received.append($0) })
+
+        observable.on(.next("1"))
+        observable.on(.next("2"))
+        observable.on(.next("3"))
+
+        XCTAssertEqual(received, ["1", "2"])
+    }
+
+    func testTakeError() {
+        let observable = Observable<String>()
+
+        var error: TestError?
+        subscription = observable.take(first: 2)
+            .asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case let .failure(underlying) = completion {
+                    error = underlying as? TestError
+                }
+            },
+            receiveValue: { _ in })
+
+        observable.on(.error(TestError.test))
+
+        XCTAssertEqual(error, .test)
+    }
+
+    func testTakeDone() {
+        let observable = Observable<String>()
+        var done = false
+
+        subscription = observable.take(first: 2)
+            .asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case .finished = completion {
+                    done = true
+                }
+            },
+            receiveValue: { _ in })
+
+        observable.on(.done)
+
+        XCTAssertEqual(done, true)
+    }
+
+    func testTakeDoneWhenCountIsReached() {
+        let observable = Observable<String>()
+        var done = false
+
+        subscription = observable.take(first: 2)
+            .asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case .finished = completion {
+                    done = true
+                }
+            },
+            receiveValue: { _ in })
+
+        observable.on(.next("1"))
+        observable.on(.next("2"))
+
+        XCTAssertEqual(done, true)
+    }
+
+    func testForward() {
+        var received: [String] = []
+        var receivedError: TestError?
+
+        let subject = Observable<String>()
+        let observable = Observable<String>()
+        observable.forward(to: subject)
+
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case let .failure(underlying) = completion {
+                    receivedError = underlying as? TestError
+                }
+            },
+            receiveValue: { received.append($0) })
+
+        observable.on(.next("1"))
+        observable.on(.error(TestError.test))
+
+        XCTAssertEqual(received.count, 1)
+        XCTAssertEqual(received.first, "1")
+        XCTAssertEqual(receivedError, .test)
+    }
+
+    func testForwardDone() {
+        var received: [String] = []
+
+        let subject = Observable<String>()
+        let observable = Observable<String>()
+        observable.forward(to: subject)
+
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { _ in },
+            receiveValue: { received.append($0) })
+
+        observable.on(.next("1"))
+        observable.on(.done)
+
+        XCTAssertEqual(received.count, 1)
+        XCTAssertEqual(received.first, "1")
+    }
+
+    func testMerge() {
+        var received: [String] = []
+
+        let a = Observable<String>()
+        let b = Observable<String>()
+
+        let subject = Observable.merge([a, b])
+
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { _ in },
+            receiveValue: { received.append($0) })
+
+        a.on(.next("1"))
+        b.on(.next("2"))
+        b.on(.done)
+
+        XCTAssertEqual(received.count, 2)
+        XCTAssertEqual(received.first, "1")
+        XCTAssertEqual(received.last, "2")
+    }
+
+    func testMergeWithoutArray() {
+        var received: [String] = []
+
+        let a = Observable<String>()
+        let b = Observable<String>()
+
+        let subject = Observable.merge(a, b)
+
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { _ in },
+            receiveValue: { received.append($0) })
+
+        a.on(.next("1"))
+        b.on(.next("2"))
+        b.on(.done)
+
+        XCTAssertEqual(received.count, 2)
+        XCTAssertEqual(received.first, "1")
+        XCTAssertEqual(received.last, "2")
+    }
+
+    func testCombineLatestNonOptional() {
+        var received: [String] = []
+
+        let string = Observable<String>()
+        let int = Observable<Int>()
+
+        let subject = Observable.combineLatest(string, int)
+
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { string, int in
+                    received.append(("\(string): \(int)"))
+            })
+
+        string.on(.next("The value"))
+        string.on(.next("The number"))
+        int.on(.next(1))
+        int.on(.next(2))
+        string.on(.next("The digit"))
+        int.on(.next(3))
+        int.on(.done)
+
+        XCTAssertEqual(received.count, 4)
+        XCTAssertEqual(received[0], "The number: 1")
+        XCTAssertEqual(received[1], "The number: 2")
+        XCTAssertEqual(received[2], "The digit: 2")
+        XCTAssertEqual(received[3], "The digit: 3")
+    }
+
+    func testCombineLatestOptional() {
+        var received: [String] = []
+
+        let string = Observable<String?>()
+        let int = Observable<Int?>()
+
+        let subject = Observable.combineLatest(string, int)
+
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { string, int in
+                    received.append(("\(string ?? "<no title>"): \(int ?? 0)"))
+            })
+
+        string.on(.next("The value"))
+        string.on(.next("The number"))
+        int.on(.next(1))
+        int.on(.next(nil))
+        string.on(.next(nil))
+        int.on(.next(3))
+        string.on(.done)
+
+        XCTAssertEqual(received.count, 4)
+        XCTAssertEqual(received[0], "The number: 1")
+        XCTAssertEqual(received[1], "The number: 0")
+        XCTAssertEqual(received[2], "<no title>: 0")
+        XCTAssertEqual(received[3], "<no title>: 3")
+    }
+
+    func testCombineLatestError_firstMember() {
+        var received: [String] = []
+
+        let string = Observable<String>()
+        let int = Observable<Int>()
+
+        let subject = Observable.combineLatest(string, int)
+
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case .failure = completion {
+                    received.append("ERROR")
+                }
+            },
+            receiveValue: { string, int in
+                received.append(("\(string): \(int)"))
+            })
+
+        string.on(.next("The number"))
+        int.on(.next(1))
+        string.on(.error(TestError.test))
+
+        string.on(.next("The digit"))
+        int.on(.next(2))
+        string.on(.error(TestError.test))
+
+        XCTAssertEqual(received.count, 2)
+        XCTAssertEqual(received.first, "The number: 1")
+        XCTAssertEqual(received.last, "ERROR")
+    }
+
+    func testCombineLatestError_secondMember() {
+        var received: [String] = []
+
+        let string = Observable<String>()
+        let int = Observable<Int>()
+
+        let subject = Observable.combineLatest(string, int)
+
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case .failure = completion {
+                    received.append("ERROR")
+                }
+            },
+            receiveValue: { _ in })
+
+        int.on(.error(TestError.test))
+        int.on(.next(1))
+
+        XCTAssertEqual(received.count, 1)
+        XCTAssertEqual(received.first, "ERROR")
+    }
+
+    func testCombineLatestDone_whenAllDone() {
+        let obs1 = Observable<String>()
+        let obs2 = Observable<Int>()
+
+        var isDone = false
+        subscription = Observable.combineLatest(obs1, obs2)
+            .asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case .finished = completion {
+                    isDone = true
+                }
+            },
+            receiveValue: { _ in })
+
+        obs1.on(.done)
+        XCTAssertFalse(isDone)
+
+        obs2.on(.done)
+        XCTAssertTrue(isDone)
+    }
+
+    func testCombineLatest3() {
+        let one = Observable<String>()
+        let two = Observable<Int>()
+        let three = Observable<Double>()
+
+        var received = [(String, Int, Double)]()
+        let subject = Observable.combineLatest(one, two, three)
+
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { received.append($0) })
+
+        one.on(.next("The string"))
+        XCTAssertTrue(received.isEmpty)
+
+        two.on(.next(1))
+        XCTAssertTrue(received.isEmpty)
+
+        three.on(.next(100.5))
+        XCTAssertEqual(received[0].0, "The string")
+        XCTAssertEqual(received[0].1, 1)
+        XCTAssertEqual(received[0].2, 100.5)
+    }
+
+    func testCombineLatest3Error_fromSecondMember() {
+        let one = Observable<String>()
+        let two = Observable<Int>()
+        let three = Observable<Double>()
+        let subject = Observable.combineLatest(one, two, three)
+
+        let exp = expectation(description: "combineLatest3 forwards error from observable")
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case .failure = completion {
+                    exp.fulfill()
+                }
+            },
+            receiveValue: { _ in })
+        two.on(.error(TestError.test))
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCombineLatest3Error_fromThirdMember() {
+        let one = Observable<String>()
+        let two = Observable<Int>()
+        let three = Observable<Double>()
+        let subject = Observable.combineLatest(one, two, three)
+
+        let exp = expectation(description: "combineLatest3 forwards error from observable")
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case .failure = completion {
+                    exp.fulfill()
+                }
+            },
+            receiveValue: { _ in })
+        three.on(.error(TestError.test))
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCombineLatest3Done_whenAllDone() {
+        let obs1 = Observable<String>()
+        let obs2 = Observable<Int>()
+        let obs3 = Observable<Double>()
+
+        var isDone = false
+        subscription = Observable.combineLatest(obs1, obs2, obs3)
+            .asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case .finished = completion {
+                    isDone = true
+                }
+            },
+            receiveValue: { _ in })
+
+        obs1.on(.done)
+        XCTAssertFalse(isDone)
+
+        obs2.on(.done)
+        XCTAssertFalse(isDone)
+
+        obs3.on(.done)
+        XCTAssertTrue(isDone)
+    }
+
+    func testCombineLatest3Optional() {
+        let one = Observable<String>()
+        let two = Observable<Int?>()
+        let three = Observable<Double>()
+
+        var received = [(String, Int?, Double)]()
+        let subject = Observable.combineLatest(one, two, three)
+
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { received.append($0) })
+
+        one.on(.next("The string"))
+        XCTAssertTrue(received.isEmpty)
+
+        two.on(.next(nil))
+        XCTAssertTrue(received.isEmpty)
+
+        three.on(.next(100.5))
+        XCTAssertEqual(received[0].0, "The string")
+        XCTAssertEqual(received[0].1, nil)
+        XCTAssertEqual(received[0].2, 100.5)
+    }
+
+    func testCombineLatest4() {
+        let one = Observable<String>()
+        let two = Observable<Int>()
+        let three = Observable<Double>()
+        let four = Observable<String>()
+
+        var received = [(String, Int, Double, String)]()
+        let subject = Observable.combineLatest(one, two, three, four)
+
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { received.append($0) })
+
+        one.on(.next("The string"))
+        XCTAssertTrue(received.isEmpty)
+
+        two.on(.next(1))
+        XCTAssertTrue(received.isEmpty)
+
+        three.on(.next(100.5))
+        XCTAssertTrue(received.isEmpty)
+
+        four.on(.next("The other string"))
+        XCTAssertEqual(received[0].0, "The string")
+        XCTAssertEqual(received[0].1, 1)
+        XCTAssertEqual(received[0].2, 100.5)
+        XCTAssertEqual(received[0].3, "The other string")
+    }
+
+    func testCombineLatest4Error_fromFirstMember() {
+        let one = Observable<String>()
+        let two = Observable<Int>()
+        let three = Observable<Double>()
+        let four = Observable<String>()
+        let subject = Observable.combineLatest(one, two, three, four)
+
+        let exp = expectation(description: "combineLatest4 forwards error from observable")
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case .failure = completion {
+                    exp.fulfill()
+                }
+            },
+            receiveValue: { _ in })
+        one.on(.error(TestError.test))
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCombineLatest4Error_fromSecondMember() {
+        let one = Observable<String>()
+        let two = Observable<Int>()
+        let three = Observable<Double>()
+        let four = Observable<String>()
+        let subject = Observable.combineLatest(one, two, three, four)
+
+        let exp = expectation(description: "combineLatest4 forwards error from observable")
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case .failure = completion {
+                    exp.fulfill()
+                }
+            },
+            receiveValue: { _ in })
+        two.on(.error(TestError.test))
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCombineLatest4Error_fromThirdMember() {
+        let one = Observable<String>()
+        let two = Observable<Int>()
+        let three = Observable<Double>()
+        let four = Observable<String>()
+        let subject = Observable.combineLatest(one, two, three, four)
+
+        let exp = expectation(description: "combineLatest4 forwards error from observable")
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case .failure = completion {
+                    exp.fulfill()
+                }
+            },
+            receiveValue: { _ in })
+        three.on(.error(TestError.test))
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCombineLatest4Error_fromFourthMember() {
+        let one = Observable<String>()
+        let two = Observable<Int>()
+        let three = Observable<Double>()
+        let four = Observable<String>()
+        let subject = Observable.combineLatest(one, two, three, four)
+
+        let exp = expectation(description: "combineLatest4 forwards error from observable")
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case .failure = completion {
+                    exp.fulfill()
+                }
+            },
+            receiveValue: { _ in })
+        four.on(.error(TestError.test))
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCombineLatest4Done_whenAllDone() {
+        let obs1 = Observable<String>()
+        let obs2 = Observable<Int>()
+        let obs3 = Observable<Double>()
+        let obs4 = Observable<Float>()
+
+        var isDone = false
+        subscription = Observable.combineLatest(obs1, obs2, obs3, obs4)
+            .asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case .finished = completion {
+                    isDone = true
+                }
+            },
+            receiveValue: { _ in })
+
+        obs1.on(.done)
+        XCTAssertFalse(isDone)
+
+        obs2.on(.done)
+        XCTAssertFalse(isDone)
+
+        obs3.on(.done)
+        XCTAssertFalse(isDone)
+
+        obs4.on(.done)
+        XCTAssertTrue(isDone)
+    }
+
+    func testCombineLatest4Optional() {
+        let one = Observable<String>()
+        let two = Observable<Int?>()
+        let three = Observable<Double>()
+        let four = Observable<String?>()
+
+        var received = [(String, Int?, Double, String?)]()
+        let subject = Observable.combineLatest(one, two, three, four)
+
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { received.append($0) })
+
+        one.on(.next("The string"))
+        XCTAssertTrue(received.isEmpty)
+
+        two.on(.next(nil))
+        XCTAssertTrue(received.isEmpty)
+
+        three.on(.next(100.5))
+        XCTAssertTrue(received.isEmpty)
+
+        four.on(.next(nil))
+        XCTAssertEqual(received[0].0, "The string")
+        XCTAssertEqual(received[0].1, nil)
+        XCTAssertEqual(received[0].2, 100.5)
+        XCTAssertEqual(received[0].3, nil)
+    }
+
+    func testObservableMap() {
+        let observable = Observable<Int>()
+        let subject = observable.map { "Number: \($0)" }
+        var received = [String]()
+
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { received.append($0) })
+
+        observable.on(.next(1))
+        observable.on(.next(10))
+
+        XCTAssertEqual(received, ["Number: 1", "Number: 10"])
+    }
+
+    func testObservableMapError() {
+        let observable = Observable<Int>()
+        let subject = observable.map { "Number: \($0)" }
+
+        let exp = expectation(description: "observable map forwards error")
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case .failure = completion {
+                    exp.fulfill()
+                }
+            },
+            receiveValue: { _ in })
+
+        observable.on(.error(TestError.test))
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testObservableMapDone() {
+        let observable = Observable<Int>()
+        let subject = observable.map { "Number: \($0)" }
+
+        let exp = expectation(description: "observable map forwards done")
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case .finished = completion {
+                    exp.fulfill()
+                }
+            },
+            receiveValue: { _ in })
+
+        observable.on(.done)
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testObservableFilter() {
+        let observable = Observable<Int>()
+        let subject = observable.filter { $0 % 2 == 0 }
+        var received = [Int]()
+
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { received.append($0) })
+
+        observable.on(.next(1))
+        observable.on(.next(2))
+        observable.on(.next(8))
+        observable.on(.next(5))
+
+        XCTAssertEqual(received, [2, 8])
+    }
+
+    func testObservableFilterError() {
+        let observable = Observable<Int>()
+        let subject = observable.filter { $0 % 2 == 0 }
+
+        let exp = expectation(description: "observable filter forwards error")
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case .failure = completion {
+                    exp.fulfill()
+                }
+            },
+            receiveValue: { _ in })
+
+        observable.on(.error(TestError.test))
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testObservableFilterDone() {
+        let observable = Observable<Int>()
+        let subject = observable.filter { $0 % 2 == 0 }
+
+        let exp = expectation(description: "observable filter forwards done")
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case .finished = completion {
+                    exp.fulfill()
+                }
+            },
+            receiveValue: { _ in })
+
+        observable.on(.done)
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testObservableFlatMap() {
+        let fetchTrigger = Observable<Void>()
+        let subject = fetchTrigger.flatMap { Variable(100).asObservable() }
+        var received = [Int]()
+
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { received.append($0) })
+        fetchTrigger.on(.next(()))
+
+        XCTAssertEqual(received, [100])
+    }
+
+    func testObservableFlatMapError() {
+        let fetchTrigger = Observable<Void>()
+        let subject = fetchTrigger.flatMap { Variable(100).asObservable() }
+
+        let exp = expectation(description: "observable flatMap forwards error")
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case .failure = completion {
+                    exp.fulfill()
+                }
+            },
+            receiveValue: { _ in })
+        fetchTrigger.on(.error(TestError.test))
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testObservableFlatMapDone() {
+        let fetchTrigger = Observable<Void>()
+        let subject = fetchTrigger.flatMap { Variable(100).asObservable() }
+
+        let exp = expectation(description: "observable flatMap forwards done")
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case .finished = completion {
+                    exp.fulfill()
+                }
+            },
+            receiveValue: { _ in })
+        fetchTrigger.on(.done)
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testZipNonOptional() {
+        var received: [String] = []
+
+        let string = Observable<String>()
+        let int = Observable<Int>()
+
+        let subject = Observable.zip(string, int)
+
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { string, int in
+                    received.append("\(string): \(int)")
+            })
+
+        string.on(.next("The value"))
+        string.on(.next("The number"))
+        int.on(.next(1))
+        int.on(.next(2))
+        string.on(.next("The digit"))
+        int.on(.next(3))
+        int.on(.done)
+
+        XCTAssertEqual(received.count, 3)
+        XCTAssertEqual(received[0], "The value: 1")
+        XCTAssertEqual(received[1], "The number: 2")
+        XCTAssertEqual(received[2], "The digit: 3")
+    }
+
+    func testZipOptional() {
+        var received: [String] = []
+
+        let string = Observable<String?>()
+        let int = Observable<Int?>()
+
+        let subject = Observable.zip(string, int)
+
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { string, int in
+                    received.append("\(string ?? "<no title>"): \(int ?? 0)")
+            })
+
+        string.on(.next("The value"))
+        string.on(.next("The number"))
+        int.on(.next(1))
+        int.on(.next(nil))
+        string.on(.next(nil))
+        int.on(.next(3))
+        string.on(.done)
+
+        XCTAssertEqual(received.count, 3)
+        XCTAssertEqual(received[0], "The value: 1")
+        XCTAssertEqual(received[1], "The number: 0")
+        XCTAssertEqual(received[2], "<no title>: 3")
+    }
+
+    func testZipCountEqualToSourceWithFewestEmissions() {
+        var received: [String] = []
+
+        let string = Observable<String>()
+        let int = Observable<Int>()
+
+        let subject = Observable.zip(string, int)
+
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { string, int in
+                    received.append("\(string): \(int)")
+            })
+
+        string.on(.next("The value"))
+        string.on(.next("The number"))
+        int.on(.next(1))
+        int.on(.next(2))
+        string.on(.next("The digit"))
+        int.on(.next(3))
+        int.on(.next(4))
+        int.on(.next(5))
+        int.on(.next(6))
+        int.on(.done)
+
+        XCTAssertEqual(received.count, 3)
+        XCTAssertEqual(received[0], "The value: 1")
+        XCTAssertEqual(received[1], "The number: 2")
+        XCTAssertEqual(received[2], "The digit: 3")
+    }
+
+    func testZipError() {
+        let one = Observable<String>()
+        let two = Observable<Int>()
+
+        let subject = Observable.zip(one, two)
+
+        let exp = expectation(description: "zip forwards error from observable")
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case .failure = completion {
+                    exp.fulfill()
+                }
+            },
+            receiveValue: { _ in })
+        one.on(.error(TestError.test))
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testZipDone() {
+        let one = Observable<String>()
+        let two = Observable<Int>()
+
+        var isDone = false
+        subscription = Observable.zip(one, two)
+            .asPublisher()
+            .sink(receiveCompletion: { completion in
+                if case .finished = completion {
+                    isDone = true
+                }
+            },
+            receiveValue: { _ in })
+
+        one.on(.done)
+        XCTAssertTrue(isDone)
+    }
+}
+#endif

--- a/SnailTests/Combine/ReplayAsPublisherTests.swift
+++ b/SnailTests/Combine/ReplayAsPublisherTests.swift
@@ -28,7 +28,7 @@ class ReplayAsPublisherTests: XCTestCase {
         subject?.on(.next("2"))
         subject?.on(.done)
 
-        subject.asPublisher()
+        subject.asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { strings.append($0) })
             .store(in: &subscriptions)

--- a/SnailTests/Combine/ReplayAsPublisherTests.swift
+++ b/SnailTests/Combine/ReplayAsPublisherTests.swift
@@ -1,0 +1,37 @@
+//  Copyright © 2021 Compass. All rights reserved.
+
+import Combine
+import Foundation
+@testable import Snail
+import XCTest
+
+@available(iOS 13.0, *)
+class ReplayAsPublisherTests: XCTestCase {
+    private var subject: Replay<String>!
+    private var subscription: AnyCancellable?
+
+    override func setUp() {
+        super.setUp()
+        subject = Replay(2)
+    }
+
+    override func tearDown() {
+        subject = nil
+        subscription = nil
+        super.tearDown()
+    }
+
+    func testReplay() {
+        var strings: [String] = []
+        subject?.on(.next("1"))
+        subject?.on(.next("2"))
+        subject?.on(.done)
+
+        subscription = subject.asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { strings.append($0) })
+
+        XCTAssertEqual(strings[0], "1")
+        XCTAssertEqual(strings[1], "2")
+    }
+}

--- a/SnailTests/Combine/ReplayAsPublisherTests.swift
+++ b/SnailTests/Combine/ReplayAsPublisherTests.swift
@@ -8,16 +8,17 @@ import XCTest
 @available(iOS 13.0, *)
 class ReplayAsPublisherTests: XCTestCase {
     private var subject: Replay<String>!
-    private var subscription: AnyCancellable?
+    private var subscriptions: Set<AnyCancellable>!
 
     override func setUp() {
         super.setUp()
         subject = Replay(2)
+        subscriptions = Set<AnyCancellable>()
     }
 
     override func tearDown() {
         subject = nil
-        subscription = nil
+        subscriptions = nil
         super.tearDown()
     }
 
@@ -27,9 +28,10 @@ class ReplayAsPublisherTests: XCTestCase {
         subject?.on(.next("2"))
         subject?.on(.done)
 
-        subscription = subject.asPublisher()
+        subject.asPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { strings.append($0) })
+            .store(in: &subscriptions)
 
         XCTAssertEqual(strings[0], "1")
         XCTAssertEqual(strings[1], "2")

--- a/SnailTests/Combine/UniqueAsPublisherTests.swift
+++ b/SnailTests/Combine/UniqueAsPublisherTests.swift
@@ -8,7 +8,7 @@ import XCTest
 @available(iOS 13.0, *)
 class UniqueAsPublisherTests: XCTestCase {
     private var subscriptions: Set<AnyCancellable>!
-    
+
     override func setUp() {
         subscriptions = Set<AnyCancellable>()
     }

--- a/SnailTests/Combine/UniqueAsPublisherTests.swift
+++ b/SnailTests/Combine/UniqueAsPublisherTests.swift
@@ -7,19 +7,24 @@ import XCTest
 
 @available(iOS 13.0, *)
 class UniqueAsPublisherTests: XCTestCase {
-    private var subscription: AnyCancellable?
+    private var subscriptions: Set<AnyCancellable>!
+    
+    override func setUp() {
+        subscriptions = Set<AnyCancellable>()
+    }
 
     override func tearDown() {
-        subscription = nil
+        subscriptions = nil
     }
 
     func testVariableChanges() {
         var events: [String?] = []
         let subject = Unique<String?>(nil)
-        subscription = subject.asObservable()
+        subject.asObservable()
             .asPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { events.append($0) })
+            .store(in: &subscriptions)
 
         subject.value = nil
         subject.value = "1"
@@ -38,10 +43,11 @@ class UniqueAsPublisherTests: XCTestCase {
         subject.value = "new"
         var result: String?
 
-        subscription = subject.asObservable()
+        subject.asObservable()
             .asPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { result = $0 })
+            .store(in: &subscriptions)
 
         XCTAssertEqual("new", result)
     }
@@ -50,10 +56,11 @@ class UniqueAsPublisherTests: XCTestCase {
         let subject = Unique("initial")
         var result: String?
 
-        subscription = subject.asObservable()
+        subject.asObservable()
             .asPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { result = $0 })
+            .store(in: &subscriptions)
 
         XCTAssertEqual("initial", result)
     }
@@ -61,10 +68,11 @@ class UniqueAsPublisherTests: XCTestCase {
     func testVariableHandlesEquatableArrays() {
         var events: [[String]] = []
         let subject = Unique<[String]>(["1", "2"])
-        subscription = subject.asObservable()
+        subject.asObservable()
             .asPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { events.append($0) })
+            .store(in: &subscriptions)
 
         subject.value = ["1", "2"]
         subject.value = ["2", "1"]
@@ -78,10 +86,11 @@ class UniqueAsPublisherTests: XCTestCase {
     func testVariableHandlesOptionalArrays() {
         var events: [[String]?] = []
         let subject = Unique<[String]?>(nil)
-        subscription = subject.asObservable()
+        subject.asObservable()
             .asPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { events.append($0) })
+            .store(in: &subscriptions)
         subject.value = ["1", "2"]
         subject.value = nil
         subject.value = nil

--- a/SnailTests/Combine/UniqueAsPublisherTests.swift
+++ b/SnailTests/Combine/UniqueAsPublisherTests.swift
@@ -1,0 +1,94 @@
+//  Copyright © 2021 Compass. All rights reserved.
+
+import Combine
+import Foundation
+@testable import Snail
+import XCTest
+
+@available(iOS 13.0, *)
+class UniqueAsPublisherTests: XCTestCase {
+    private var subscription: AnyCancellable?
+
+    override func tearDown() {
+        subscription = nil
+    }
+
+    func testVariableChanges() {
+        var events: [String?] = []
+        let subject = Unique<String?>(nil)
+        subscription = subject.asObservable()
+            .asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { events.append($0) })
+
+        subject.value = nil
+        subject.value = "1"
+        subject.value = "2"
+        subject.value = "2"
+        subject.value = "2"
+        XCTAssertEqual(events[0], nil)
+        XCTAssertEqual(events[1], "1")
+        XCTAssertEqual(events[2], "2")
+        XCTAssertEqual(subject.value, "2")
+        XCTAssertEqual(events.count, 3)
+    }
+
+    func testVariableNotifiesOnSubscribe() {
+        let subject = Unique("initial")
+        subject.value = "new"
+        var result: String?
+
+        subscription = subject.asObservable()
+            .asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { result = $0 })
+
+        XCTAssertEqual("new", result)
+    }
+
+    func testVariableNotifiesInitialOnSubscribe() {
+        let subject = Unique("initial")
+        var result: String?
+
+        subscription = subject.asObservable()
+            .asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { result = $0 })
+
+        XCTAssertEqual("initial", result)
+    }
+
+    func testVariableHandlesEquatableArrays() {
+        var events: [[String]] = []
+        let subject = Unique<[String]>(["1", "2"])
+        subscription = subject.asObservable()
+            .asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { events.append($0) })
+
+        subject.value = ["1", "2"]
+        subject.value = ["2", "1"]
+        subject.value = ["2", "1"]
+        subject.value = ["1", "2"]
+        XCTAssertEqual(events[0], ["1", "2"])
+        XCTAssertEqual(events[1], ["2", "1"])
+        XCTAssertEqual(events[2], ["1", "2"])
+    }
+
+    func testVariableHandlesOptionalArrays() {
+        var events: [[String]?] = []
+        let subject = Unique<[String]?>(nil)
+        subscription = subject.asObservable()
+            .asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { events.append($0) })
+        subject.value = ["1", "2"]
+        subject.value = nil
+        subject.value = nil
+        subject.value = ["1", "2"]
+        XCTAssertEqual(events[0], nil)
+        XCTAssertEqual(events[1], ["1", "2"])
+        XCTAssertEqual(events[2], nil)
+        XCTAssertEqual(events[3], ["1", "2"])
+    }
+}

--- a/SnailTests/Combine/UniqueAsPublisherTests.swift
+++ b/SnailTests/Combine/UniqueAsPublisherTests.swift
@@ -21,7 +21,7 @@ class UniqueAsPublisherTests: XCTestCase {
         var events: [String?] = []
         let subject = Unique<String?>(nil)
         subject.asObservable()
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { events.append($0) })
             .store(in: &subscriptions)
@@ -44,7 +44,7 @@ class UniqueAsPublisherTests: XCTestCase {
         var result: String?
 
         subject.asObservable()
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { result = $0 })
             .store(in: &subscriptions)
@@ -57,7 +57,7 @@ class UniqueAsPublisherTests: XCTestCase {
         var result: String?
 
         subject.asObservable()
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { result = $0 })
             .store(in: &subscriptions)
@@ -69,7 +69,7 @@ class UniqueAsPublisherTests: XCTestCase {
         var events: [[String]] = []
         let subject = Unique<[String]>(["1", "2"])
         subject.asObservable()
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { events.append($0) })
             .store(in: &subscriptions)
@@ -87,7 +87,7 @@ class UniqueAsPublisherTests: XCTestCase {
         var events: [[String]?] = []
         let subject = Unique<[String]?>(nil)
         subject.asObservable()
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { events.append($0) })
             .store(in: &subscriptions)

--- a/SnailTests/Combine/VariableAsPublisherTests.swift
+++ b/SnailTests/Combine/VariableAsPublisherTests.swift
@@ -7,19 +7,24 @@ import XCTest
 
 @available(iOS 13.0, *)
 class VariableAsPublisherTests: XCTestCase {
-    private var subscription: AnyCancellable?
+    private var subscriptions: Set<AnyCancellable>!
+    
+    override func setUp() {
+        subscriptions = Set<AnyCancellable>()
+    }
 
     override func tearDown() {
-        subscription = nil
+        subscriptions = nil
     }
 
     func testVariableChanges() {
         var events: [String?] = []
         let subject = Variable<String?>(nil)
-        subscription = subject.asObservable()
+        subject.asObservable()
             .asPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { events.append($0) })
+            .store(in: &subscriptions)
         subject.value = "1"
         subject.value = "2"
         XCTAssertEqual(events[0], nil)
@@ -33,10 +38,11 @@ class VariableAsPublisherTests: XCTestCase {
         subject.value = "new"
         var result: String?
 
-        subscription = subject.asObservable()
+        subject.asObservable()
             .asPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { result = $0 })
+            .store(in: &subscriptions)
 
         XCTAssertEqual("new", result)
     }
@@ -45,10 +51,11 @@ class VariableAsPublisherTests: XCTestCase {
         let subject = Variable("initial")
         var result: String?
 
-        subscription = subject.asObservable()
+        subject.asObservable()
             .asPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { result = $0 })
+            .store(in: &subscriptions)
 
         XCTAssertEqual("initial", result)
     }
@@ -58,10 +65,11 @@ class VariableAsPublisherTests: XCTestCase {
         subject.value = "new"
         var subjectCharactersCount: Int?
 
-        subscription = subject.asObservable()
+        subject.asObservable()
             .asPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { subjectCharactersCount = $0.count })
+            .store(in: &subscriptions)
 
         XCTAssertEqual(subject.value.count, subjectCharactersCount)
     }
@@ -70,10 +78,11 @@ class VariableAsPublisherTests: XCTestCase {
         let subject = Variable("initial")
         var subjectCharactersCount: Int?
 
-        subscription = subject.asObservable()
+        subject.asObservable()
             .asPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { subjectCharactersCount = $0.count })
+            .store(in: &subscriptions)
 
         XCTAssertEqual(subject.value.count, subjectCharactersCount)
     }
@@ -82,10 +91,11 @@ class VariableAsPublisherTests: XCTestCase {
         let subject = Unique("sameValue")
         var firedCount = 0
 
-        subscription = subject.asObservable()
+        subject.asObservable()
             .asPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { _ in firedCount += 1 })
+            .store(in: &subscriptions)
 
         subject.value = "sameValue"
 
@@ -96,10 +106,11 @@ class VariableAsPublisherTests: XCTestCase {
         let subject = Variable("sameValue")
         var firedCount = 0
 
-        subscription = subject.asObservable()
+        subject.asObservable()
             .asPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { _ in firedCount += 1 })
+            .store(in: &subscriptions)
 
         subject.value = "sameValue"
 

--- a/SnailTests/Combine/VariableAsPublisherTests.swift
+++ b/SnailTests/Combine/VariableAsPublisherTests.swift
@@ -21,7 +21,7 @@ class VariableAsPublisherTests: XCTestCase {
         var events: [String?] = []
         let subject = Variable<String?>(nil)
         subject.asObservable()
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { events.append($0) })
             .store(in: &subscriptions)
@@ -39,7 +39,7 @@ class VariableAsPublisherTests: XCTestCase {
         var result: String?
 
         subject.asObservable()
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { result = $0 })
             .store(in: &subscriptions)
@@ -52,7 +52,7 @@ class VariableAsPublisherTests: XCTestCase {
         var result: String?
 
         subject.asObservable()
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { result = $0 })
             .store(in: &subscriptions)
@@ -66,7 +66,7 @@ class VariableAsPublisherTests: XCTestCase {
         var subjectCharactersCount: Int?
 
         subject.asObservable()
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { subjectCharactersCount = $0.count })
             .store(in: &subscriptions)
@@ -79,7 +79,7 @@ class VariableAsPublisherTests: XCTestCase {
         var subjectCharactersCount: Int?
 
         subject.asObservable()
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { subjectCharactersCount = $0.count })
             .store(in: &subscriptions)
@@ -92,7 +92,7 @@ class VariableAsPublisherTests: XCTestCase {
         var firedCount = 0
 
         subject.asObservable()
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { _ in firedCount += 1 })
             .store(in: &subscriptions)
@@ -107,7 +107,7 @@ class VariableAsPublisherTests: XCTestCase {
         var firedCount = 0
 
         subject.asObservable()
-            .asPublisher()
+            .asAnyPublisher()
             .sink(receiveCompletion: { _ in },
                   receiveValue: { _ in firedCount += 1 })
             .store(in: &subscriptions)

--- a/SnailTests/Combine/VariableAsPublisherTests.swift
+++ b/SnailTests/Combine/VariableAsPublisherTests.swift
@@ -1,0 +1,108 @@
+//  Copyright © 2021 Compass. All rights reserved.
+
+import Combine
+import Foundation
+@testable import Snail
+import XCTest
+
+@available(iOS 13.0, *)
+class VariableAsPublisherTests: XCTestCase {
+    private var subscription: AnyCancellable?
+
+    override func tearDown() {
+        subscription = nil
+    }
+
+    func testVariableChanges() {
+        var events: [String?] = []
+        let subject = Variable<String?>(nil)
+        subscription = subject.asObservable()
+            .asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { events.append($0) })
+        subject.value = "1"
+        subject.value = "2"
+        XCTAssertEqual(events[0], nil)
+        XCTAssertEqual(events[1], "1")
+        XCTAssertEqual(events[2], "2")
+        XCTAssertEqual(subject.value, "2")
+    }
+
+    func testVariableNotifiesOnSubscribe() {
+        let subject = Variable("initial")
+        subject.value = "new"
+        var result: String?
+
+        subscription = subject.asObservable()
+            .asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { result = $0 })
+
+        XCTAssertEqual("new", result)
+    }
+
+    func testVariableNotifiesInitialOnSubscribe() {
+        let subject = Variable("initial")
+        var result: String?
+
+        subscription = subject.asObservable()
+            .asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { result = $0 })
+
+        XCTAssertEqual("initial", result)
+    }
+
+    func testMappedVariableNotifiesOnSubscribe() {
+        let subject = Variable("initial")
+        subject.value = "new"
+        var subjectCharactersCount: Int?
+
+        subscription = subject.asObservable()
+            .asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { subjectCharactersCount = $0.count })
+
+        XCTAssertEqual(subject.value.count, subjectCharactersCount)
+    }
+
+    func testMappedVariableNotifiesInitialOnSubscribe() {
+        let subject = Variable("initial")
+        var subjectCharactersCount: Int?
+
+        subscription = subject.asObservable()
+            .asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { subjectCharactersCount = $0.count })
+
+        XCTAssertEqual(subject.value.count, subjectCharactersCount)
+    }
+
+    func testUniqueFireCounts() {
+        let subject = Unique("sameValue")
+        var firedCount = 0
+
+        subscription = subject.asObservable()
+            .asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { _ in firedCount += 1 })
+
+        subject.value = "sameValue"
+
+        XCTAssertEqual(firedCount, 1)
+    }
+
+    func testVariableFireCounts() {
+        let subject = Variable("sameValue")
+        var firedCount = 0
+
+        subscription = subject.asObservable()
+            .asPublisher()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { _ in firedCount += 1 })
+
+        subject.value = "sameValue"
+
+        XCTAssertEqual(firedCount, 2)
+    }
+}

--- a/SnailTests/Combine/VariableAsPublisherTests.swift
+++ b/SnailTests/Combine/VariableAsPublisherTests.swift
@@ -8,7 +8,7 @@ import XCTest
 @available(iOS 13.0, *)
 class VariableAsPublisherTests: XCTestCase {
     private var subscriptions: Set<AnyCancellable>!
-    
+
     override func setUp() {
         subscriptions = Set<AnyCancellable>()
     }


### PR DESCRIPTION
# Release Notes

- A first attempt at providing a bridge for Snail and Combine
- Adds an extension ([`asPublisher()`](https://github.com/UrbanCompass/Snail/compare/thomas/observable-to-publisher?expand=1#diff-b4484276d83b054c7ca911decc2ee1615fab4e3b4ebd5051c8eec371e9ce7f70R13) to lift all `ObservableType`s into a Combine publisher
- Adds test similar test cases (`ObservableAsPublisherTests`) based on original `ObservableTests`