### PR TITLE
Add twoWayBind to Variable<T>

### DIFF
--- a/Snail.xcodeproj/project.pbxproj
+++ b/Snail.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		CBE54E671DFB4F3F0008DD64 /* VariableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE54E661DFB4F3F0008DD64 /* VariableTests.swift */; };
 		CBE54E6D1DFB6A910008DD64 /* UIControlExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE54E6C1DFB6A910008DD64 /* UIControlExtensions.swift */; };
 		CBE54E6F1DFB797F0008DD64 /* UIViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE54E6E1DFB797F0008DD64 /* UIViewExtensions.swift */; };
+		D2538A672669952000197A09 /* TwoWayBind.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2538A662669952000197A09 /* TwoWayBind.swift */; };
 		DEEDA8EB2051BCB4000FE578 /* NotificationCenterExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEDA8EA2051BCB4000FE578 /* NotificationCenterExtensions.swift */; };
 		DEF9B98D1FD5D8FD00F8514E /* UniqueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF9B98C1FD5D8FD00F8514E /* UniqueTests.swift */; };
 		DEF9B98F1FD5FE5800F8514E /* Unique.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF9B98E1FD5FE5800F8514E /* Unique.swift */; };
@@ -75,6 +76,7 @@
 		CBE54E661DFB4F3F0008DD64 /* VariableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VariableTests.swift; sourceTree = "<group>"; };
 		CBE54E6C1DFB6A910008DD64 /* UIControlExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIControlExtensions.swift; sourceTree = "<group>"; };
 		CBE54E6E1DFB797F0008DD64 /* UIViewExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewExtensions.swift; sourceTree = "<group>"; };
+		D2538A662669952000197A09 /* TwoWayBind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoWayBind.swift; sourceTree = "<group>"; };
 		DEEDA8EA2051BCB4000FE578 /* NotificationCenterExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationCenterExtensions.swift; sourceTree = "<group>"; };
 		DEF9B98C1FD5D8FD00F8514E /* UniqueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniqueTests.swift; sourceTree = "<group>"; };
 		DEF9B98E1FD5FE5800F8514E /* Unique.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Unique.swift; sourceTree = "<group>"; };
@@ -145,6 +147,7 @@
 				24FABD591DFF0B48005CF84E /* Replay.swift */,
 				2408FA8F2112A15900B9F59E /* Scheduler.swift */,
 				CBE54A791E5A16AC00971F74 /* Subscriber.swift */,
+				D2538A662669952000197A09 /* TwoWayBind.swift */,
 				DEF9B98E1FD5FE5800F8514E /* Unique.swift */,
 				CBE54E5F1DFB39510008DD64 /* Variable.swift */,
 				CBE54E5C1DFB39510008DD64 /* Extensions */,
@@ -333,6 +336,7 @@
 				24FABD5A1DFF0B48005CF84E /* Replay.swift in Sources */,
 				DEF9B98F1FD5FE5800F8514E /* Unique.swift in Sources */,
 				CBE54E6F1DFB797F0008DD64 /* UIViewExtensions.swift in Sources */,
+				D2538A672669952000197A09 /* TwoWayBind.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Snail/TwoWayBind.swift
+++ b/Snail/TwoWayBind.swift
@@ -1,0 +1,8 @@
+//  Copyright © 2021 Compass. All rights reserved.
+
+import Foundation
+
+protocol TwoWayBind {
+    associatedtype T
+    func twoWayBind(with: Variable<T>)
+}

--- a/Snail/TwoWayBind.swift
+++ b/Snail/TwoWayBind.swift
@@ -3,6 +3,6 @@
 import Foundation
 
 protocol TwoWayBind {
-    associatedtype T
-    func twoWayBind(with: Variable<T>)
+    associatedtype BindableType
+    func twoWayBind(with: BindableType)
 }

--- a/Snail/Variable.swift
+++ b/Snail/Variable.swift
@@ -49,6 +49,8 @@ public class Variable<T> {
 }
 
 extension Variable: TwoWayBind {
+    public typealias BindableType = Variable<T>
+
     private struct Emission<T> {
         let value: T
         let direction: Direction
@@ -59,11 +61,11 @@ extension Variable: TwoWayBind {
         case rightToLeft
     }
 
-    public func twoWayBind(with: Variable<T>) {
-        let left: Observable<Emission<T>> = self.asObservable().map { Emission(value: $0, direction: .leftToRight) }
-        let right: Observable<Emission<T>> = with.asObservable().map { Emission(value: $0, direction: .rightToLeft) }
+    public func twoWayBind(with: BindableType) {
+        let leftEmitter: Observable<Emission<T>> = self.asObservable().map { Emission(value: $0, direction: .leftToRight) }
+        let rightEmitter: Observable<Emission<T>> = with.asObservable().map { Emission(value: $0, direction: .rightToLeft) }
 
-        Observable.merge([left, right]).subscribe(onNext: { element in
+        Observable.merge([leftEmitter, rightEmitter]).subscribe(onNext: { element in
             switch element.direction {
             case .leftToRight:
                 with.currentValue = element.value
@@ -72,6 +74,6 @@ extension Variable: TwoWayBind {
             }
         })
 
-        left.on(.next(Emission(value: with.value, direction: .rightToLeft)))
+        leftEmitter.on(.next(Emission(value: with.value, direction: .rightToLeft)))
     }
 }

--- a/Snail/Variable.swift
+++ b/Snail/Variable.swift
@@ -43,6 +43,29 @@ public class Variable<T> {
         return newVariable
     }
 
+    public func twoWayBind(with: Variable<T>) {
+        self.value = with.value
+        var skipSelfEmission: Bool = false
+        var skipWithEmission: Bool = false
+
+        self.asObservable().subscribe(onNext: { [weak with] value in
+            guard !skipWithEmission else {
+                skipWithEmission = false
+                return
+            }
+            skipSelfEmission = true
+            with?.value = value
+        })
+        with.asObservable().subscribe(onNext: { [weak self] value in
+            guard !skipSelfEmission else {
+                skipSelfEmission = false
+                return
+            }
+            skipWithEmission = true
+            self?.value = value
+        })
+    }
+
     deinit {
         subject.on(.done)
     }

--- a/Snail/Variable.swift
+++ b/Snail/Variable.swift
@@ -62,11 +62,11 @@ extension Variable: TwoWayBind {
     }
 
     public func twoWayBind(with: BindableType) {
-        var updatingLeft: Bool = false
-        var updatingRight: Bool = false
-
         let leftEmitter: Observable<Emission<T>> = self.asObservable().map { Emission(value: $0, direction: .leftToRight) }
         let rightEmitter: Observable<Emission<T>> = with.asObservable().map { Emission(value: $0, direction: .rightToLeft) }
+
+        var updatingLeft: Bool = false
+        var updatingRight: Bool = false
 
         Observable.merge([leftEmitter, rightEmitter]).subscribe(onNext: { element in
             switch element.direction {

--- a/SnailTests/VariableTests.swift
+++ b/SnailTests/VariableTests.swift
@@ -136,4 +136,33 @@ class VariableTests: XCTestCase {
         XCTAssertEqual(subject.value, "eight")
         XCTAssertEqual(otherSubject.value, "eight")
     }
+
+    func testTwoWayBindWithOtherVariableSubscriptionsCounts() {
+        let subject = Variable(0)
+        let otherSubject = Variable(0)
+
+        var subjectCount = 0
+        var otherSubjectCount = 0
+
+        subject.twoWayBind(with: otherSubject)
+
+        subject.asObservable().subscribe(onNext: { _ in
+            subjectCount += 1
+        })
+        otherSubject.asObservable().subscribe(onNext: { _ in
+            otherSubjectCount += 1
+        })
+
+        for number in 1...9 {
+            if number.isMultiple(of: 2) {
+                otherSubject.value = number
+            } else {
+                subject.value = number
+            }
+        }
+
+        XCTAssertEqual(subjectCount, otherSubjectCount)
+        XCTAssertEqual(subjectCount, 10)
+        XCTAssertEqual(otherSubjectCount, 10)
+    }
 }

--- a/SnailTests/VariableTests.swift
+++ b/SnailTests/VariableTests.swift
@@ -104,4 +104,36 @@ class VariableTests: XCTestCase {
         observedVariable.value = "three"
         XCTAssertEqual(subject.value, "three")
     }
+
+    func testTwoWayBindWitheOtherVariable() {
+        let subject = Variable("one")
+        let otherSubject = Variable("two")
+
+        subject.twoWayBind(with: otherSubject)
+        XCTAssertEqual(subject.value, "two")
+
+        subject.value = "three"
+        XCTAssertEqual(subject.value, "three")
+        XCTAssertEqual(otherSubject.value, "three")
+
+        subject.value = "four"
+        XCTAssertEqual(subject.value, "four")
+        XCTAssertEqual(otherSubject.value, "four")
+
+        otherSubject.value = "five"
+        XCTAssertEqual(subject.value, "five")
+        XCTAssertEqual(otherSubject.value, "five")
+
+        otherSubject.value = "six"
+        XCTAssertEqual(subject.value, "six")
+        XCTAssertEqual(otherSubject.value, "six")
+
+        subject.value = "seven"
+        XCTAssertEqual(subject.value, "seven")
+        XCTAssertEqual(otherSubject.value, "seven")
+
+        otherSubject.value = "eight"
+        XCTAssertEqual(subject.value, "eight")
+        XCTAssertEqual(otherSubject.value, "eight")
+    }
 }

--- a/SnailTests/VariableTests.swift
+++ b/SnailTests/VariableTests.swift
@@ -137,20 +137,20 @@ class VariableTests: XCTestCase {
         XCTAssertEqual(otherSubject.value, "eight")
     }
 
-    func testTwoWayBindWithOtherVariableSubscriptionsCounts() {
+    func testTwoWayBindWithOtherVariableFireCounts() {
         let subject = Variable(0)
         let otherSubject = Variable(0)
 
-        var subjectCount = 0
-        var otherSubjectCount = 0
+        var subjectFireCount = 0
+        var otherSubjectFireCount = 0
 
         subject.twoWayBind(with: otherSubject)
 
         subject.asObservable().subscribe(onNext: { _ in
-            subjectCount += 1
+            subjectFireCount += 1
         })
         otherSubject.asObservable().subscribe(onNext: { _ in
-            otherSubjectCount += 1
+            otherSubjectFireCount += 1
         })
 
         for number in 1...9 {
@@ -161,8 +161,49 @@ class VariableTests: XCTestCase {
             }
         }
 
-        XCTAssertEqual(subjectCount, otherSubjectCount)
-        XCTAssertEqual(subjectCount, 10)
-        XCTAssertEqual(otherSubjectCount, 10)
+        XCTAssertEqual(subjectFireCount, otherSubjectFireCount)
+        XCTAssertEqual(subjectFireCount, 10)
+        XCTAssertEqual(otherSubjectFireCount, 10)
+    }
+
+    func testTwoWayBindWithUniques() {
+        let subject = Unique("one")
+        let otherSubject = Unique("two")
+
+        var subjectFireCount = 0
+        var otherSubjectFireCount = 0
+
+        subject.twoWayBind(with: otherSubject)
+
+        subject.asObservable().subscribe(onNext: { _ in
+            subjectFireCount += 1
+        })
+        otherSubject.asObservable().subscribe(onNext: { _ in
+            otherSubjectFireCount += 1
+        })
+
+        XCTAssertEqual(subject.value, "two")
+
+        subject.value = "three"
+        XCTAssertEqual(subject.value, "three")
+        XCTAssertEqual(otherSubject.value, "three")
+
+        otherSubject.value = "four"
+        XCTAssertEqual(subject.value, "four")
+        XCTAssertEqual(otherSubject.value, "four")
+
+        for _ in 1...10 {
+            subject.value = "four"
+            XCTAssertEqual(subject.value, "four")
+            XCTAssertEqual(otherSubject.value, "four")
+
+            otherSubject.value = "four"
+            XCTAssertEqual(subject.value, "four")
+            XCTAssertEqual(otherSubject.value, "four")
+        }
+
+        XCTAssertEqual(subjectFireCount, otherSubjectFireCount)
+        XCTAssertEqual(subjectFireCount, 3)
+        XCTAssertEqual(otherSubjectFireCount, 3)
     }
 }


### PR DESCRIPTION
### Summary
* Create `TwoWayBind` protocol
* Connect two `Variable<T>`s so that any update to one, updates the other.

```
VarA<Int> -----1----------2-------3-------4---------------5-------------------------------->
                \         |        \       \              |
                 |       /          |       |            /
VarB<Int> -------1------2-----------3-------4-----------5---------------------------------->

varA.twoWayBind(with: varB)

varA.asObservable().subscribe(onNext: { value in
    print(value) // 1, 2, 3, 4, 5
}
varB.asObservable().subscribe(onNext: { value in
    print(value) // 1, 2, 3, 4, 5
}
```