### PR TITLE
Remove discardableResult attribute from subscribe method

### DIFF
--- a/Snail/Extensions/UIViewExtensions.swift
+++ b/Snail/Extensions/UIViewExtensions.swift
@@ -20,7 +20,7 @@ public extension UIView {
 
         let tap = UITapGestureRecognizer()
         addGestureRecognizer(tap)
-        tap.asObservable().subscribe(onNext: { [weak observable] _ in observable?.on(.next(())) })
+        tap.asObservable().subscribe(onNext: { [weak observable] _ in observable?.on(.next(())) }).add(to: disposer)
 
         return observable
     }
@@ -41,6 +41,7 @@ public extension UIView {
             }
             observable.on(.next((offset.cgRectValue.size.height, duration)))
         })
+        .add(to: disposer)
 
         observe(event: UIResponder.keyboardWillHideNotification).subscribe(onNext: { notification in
             guard let duration = notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double else {
@@ -48,6 +49,8 @@ public extension UIView {
             }
             observable.on(.next((0, duration)))
         })
+        .add(to: disposer)
+
         return observable
     }
 

--- a/Snail/Extensions/URLSessionExtensions.swift
+++ b/Snail/Extensions/URLSessionExtensions.swift
@@ -19,6 +19,17 @@ extension URLSession {
         }
     }
 
+    private static var disposerKey = "com.compass.Snail.URLSession.Disposer"
+
+    public var disposer: Disposer {
+        if let disposer = objc_getAssociatedObject(self, &URLSession.disposerKey) as? Disposer {
+            return disposer
+        }
+        let disposer = Disposer()
+        objc_setAssociatedObject(self, &URLSession.disposerKey, disposer, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        return disposer
+    }
+
     public func decoded<T: Codable>(request: URLRequest) -> Observable<(T, URLResponse)> {
         let observer = Replay<(T, URLResponse)>(1)
         data(request: request).subscribe(onNext: { data, response in
@@ -28,6 +39,7 @@ extension URLSession {
             }
             observer.on(.next((codedObject, response)))
         }, onError: { observer.on(.error($0)) })
+        .add(to: disposer)
         return observer
     }
 
@@ -40,6 +52,7 @@ extension URLSession {
             }
             observer.on(.next((dictionary, response)))
         }, onError: { observer.on(.error($0)) })
+        .add(to: disposer)
         return observer
     }
 
@@ -52,6 +65,7 @@ extension URLSession {
             }
             observer.on(.next((dictionary, response)))
         }, onError: { observer.on(.error($0)) })
+        .add(to: disposer)
         return observer
     }
 
@@ -87,6 +101,7 @@ extension URLSession {
             observer.on(.next((image, response)))
             observer.on(.done)
         }, onError: { observer.on(.error($0)) })
+        .add(to: disposer)
         return observer
     }
     #endif

--- a/Snail/Observable.swift
+++ b/Snail/Observable.swift
@@ -21,7 +21,7 @@ public class Observable<T>: ObservableType {
         }
     }
 
-    @discardableResult public func subscribe(queue: DispatchQueue? = nil, onNext: ((T) -> Void)? = nil, onError: ((Error) -> Void)? = nil, onDone: (() -> Void)? = nil) -> Subscriber<T> {
+    public func subscribe(queue: DispatchQueue? = nil, onNext: ((T) -> Void)? = nil, onError: ((Error) -> Void)? = nil, onDone: (() -> Void)? = nil) -> Subscriber<T> {
         let subscriber = Subscriber(queue: queue, observable: self, handler: createHandler(onNext: onNext, onError: onError, onDone: onDone))
         if let stoppedEvent = stoppedEvent {
             notify(subscriber: subscriber, event: stoppedEvent)
@@ -61,7 +61,7 @@ public class Observable<T>: ObservableType {
 
     public func on(_ queue: DispatchQueue) -> Observable<T> {
         let observable = Observable<T>()
-        subscribe(queue: queue,
+        _ = subscribe(queue: queue,
                   onNext: { observable.on(.next($0)) },
                   onError: { observable.on(.error($0)) },
                   onDone: { observable.on(.done) })
@@ -89,7 +89,7 @@ public class Observable<T>: ObservableType {
     public func map<U>(_ transform: @escaping (T) -> U) -> Observable<U> {
         let transformed = Observable<U>()
 
-        subscribe(
+        _ = subscribe(
             onNext: { value in
                 transformed.on(.next(transform(value)))
             },
@@ -107,7 +107,7 @@ public class Observable<T>: ObservableType {
     public func flatMap<U>( _ transform: @escaping (T) -> Observable<U>) -> Observable<U> {
         let flatMapped = Observable<U>()
 
-        subscribe(
+        _ = subscribe(
             onNext: { value in
                 let obs = transform(value)
                 obs.forward(to: flatMapped)
@@ -126,7 +126,7 @@ public class Observable<T>: ObservableType {
     public func filter(_ isIncluded: @escaping (T) -> Bool) -> Observable<T> {
         let filtered = Observable<T>()
 
-        subscribe(
+        _ = subscribe(
             onNext: { value in
                 guard isIncluded(value) else { return }
                 filtered.on(.next(value))
@@ -155,7 +155,7 @@ public class Observable<T>: ObservableType {
 
         let semaphore = DispatchSemaphore(value: 0)
 
-        subscribe(onNext: { value in
+        _ = subscribe(onNext: { value in
             result = value
             semaphore.signal()
         }, onError: { err in
@@ -168,7 +168,7 @@ public class Observable<T>: ObservableType {
         if let timeout = timeout {
             _ = semaphore.wait(timeout: .now() + timeout)
         } else {
-            _ = semaphore.wait()
+            semaphore.wait()
         }
 
         if let error = error {
@@ -188,7 +188,7 @@ public class Observable<T>: ObservableType {
         scheduler.start()
 
         var next: T?
-        scheduler.observable.subscribe(onNext: {
+        _ = scheduler.observable.subscribe(onNext: {
             guard let nextValue = next else {
                 return
             }
@@ -196,7 +196,7 @@ public class Observable<T>: ObservableType {
             next = nil
         })
 
-        subscribe(onNext: { next = $0 }, onError: { observable.on(.error($0)) }, onDone: { observable.on(.done) })
+        _ = subscribe(onNext: { next = $0 }, onError: { observable.on(.error($0)) }, onDone: { observable.on(.done) })
         return observable
     }
 
@@ -205,7 +205,7 @@ public class Observable<T>: ObservableType {
         let scheduler = Scheduler(delay)
 
         var next: T?
-        scheduler.observable.subscribe(onNext: {
+        _ = scheduler.observable.subscribe(onNext: {
             guard let nextValue = next else {
                 return
             }
@@ -213,7 +213,7 @@ public class Observable<T>: ObservableType {
             next = nil
         })
 
-        subscribe(onNext: {
+        _ = subscribe(onNext: {
             next = $0
             scheduler.start()
         }, onError: { observable.on(.error($0)) }, onDone: { observable.on(.done) })
@@ -224,7 +224,7 @@ public class Observable<T>: ObservableType {
         let observable = Observable<T>()
         var count = first
 
-        subscribe(onNext: {
+        _ = subscribe(onNext: {
             if count == 0 {
                 observable.on(.next($0))
             }
@@ -241,7 +241,7 @@ public class Observable<T>: ObservableType {
         let observable = Observable<T>()
         var taken = 0
 
-        subscribe(onNext: {
+        _ = subscribe(onNext: {
             if taken < count {
                 observable.on(.next($0))
                 taken += 1
@@ -275,7 +275,7 @@ public class Observable<T>: ObservableType {
     }
 
     public func forward(to: Observable<T>) {
-        subscribe(onNext: {
+        _ = subscribe(onNext: {
             to.on(.next($0))
         }, onError: {
             to.on(.error($0))
@@ -313,7 +313,7 @@ public class Observable<T>: ObservableType {
             combined.on(.done)
         }
 
-        input1.subscribe(onNext: {
+        _ = input1.subscribe(onNext: {
             input1Result.value = $0
             triggerIfNeeded()
         }, onError: {
@@ -323,7 +323,7 @@ public class Observable<T>: ObservableType {
             finishIfNeeded()
         })
 
-        input2.subscribe(onNext: {
+        _ = input2.subscribe(onNext: {
             input2Result.value = $0
             triggerIfNeeded()
         }, onError: {
@@ -359,7 +359,7 @@ public class Observable<T>: ObservableType {
             combined.on(.done)
         }
 
-        input1.subscribe(onNext: {
+        _ = input1.subscribe(onNext: {
             input1Result.value = $0
             triggerIfNeeded()
         }, onError: {
@@ -369,7 +369,7 @@ public class Observable<T>: ObservableType {
             finishIfNeeded()
         })
 
-        input2.subscribe(onNext: {
+        _ = input2.subscribe(onNext: {
             input2Result.value = $0
             triggerIfNeeded()
         }, onError: {
@@ -379,7 +379,7 @@ public class Observable<T>: ObservableType {
             finishIfNeeded()
         })
 
-        input3.subscribe(onNext: {
+        _ = input3.subscribe(onNext: {
             input3Result.value = $0
             triggerIfNeeded()
         }, onError: {
@@ -418,7 +418,7 @@ public class Observable<T>: ObservableType {
             combined.on(.done)
         }
 
-        input1.subscribe(onNext: {
+        _ = input1.subscribe(onNext: {
             input1Result.value = $0
             triggerIfNeeded()
         }, onError: {
@@ -428,7 +428,7 @@ public class Observable<T>: ObservableType {
             finishIfNeeded()
         })
 
-        input2.subscribe(onNext: {
+        _ = input2.subscribe(onNext: {
             input2Result.value = $0
             triggerIfNeeded()
         }, onError: {
@@ -438,7 +438,7 @@ public class Observable<T>: ObservableType {
             finishIfNeeded()
         })
 
-        input3.subscribe(onNext: {
+        _ = input3.subscribe(onNext: {
             input3Result.value = $0
             triggerIfNeeded()
         }, onError: {
@@ -448,7 +448,7 @@ public class Observable<T>: ObservableType {
             finishIfNeeded()
         })
 
-        input4.subscribe(onNext: {
+        _ = input4.subscribe(onNext: {
             input4Result.value = $0
             triggerIfNeeded()
         }, onError: {
@@ -477,7 +477,7 @@ public class Observable<T>: ObservableType {
             combined.on(.next((value1, value2)))
         }
 
-        input1.subscribe(onNext: {
+        _ = input1.subscribe(onNext: {
             input1Result.append($0)
             triggerIfNeeded()
         }, onError: {
@@ -486,7 +486,7 @@ public class Observable<T>: ObservableType {
             combined.on(.done)
         })
 
-        input2.subscribe(onNext: {
+        _ = input2.subscribe(onNext: {
             input2Result.append($0)
             triggerIfNeeded()
         }, onError: {

--- a/Snail/Variable.swift
+++ b/Snail/Variable.swift
@@ -6,6 +6,7 @@ public class Variable<T> {
     let subject: Replay<T>
     var lock = NSRecursiveLock()
     var currentValue: T
+    private let disposer = Disposer()
 
     public var value: T {
         get {
@@ -31,15 +32,18 @@ public class Variable<T> {
         return subject
     }
 
-    public func bind(to variable: Variable<T>) {
-        variable.asObservable().subscribe(onNext: { [weak self] value in
+    public func bind(to variable: Variable<T>) -> Subscriber<T> {
+        return variable.asObservable().subscribe(onNext: { [weak self] value in
             self?.value = value
         })
     }
 
     public func map<U>(_ transform: @escaping (T) -> U) -> Variable<U> {
         let newVariable = Variable<U>(transform(value))
-        asObservable().subscribe(onNext: { _ in newVariable.value = transform(self.value) })
+        asObservable().subscribe(onNext: { [weak self] _ in
+            guard let self = self else { return }
+            newVariable.value = transform(self.value)
+        }).add(to: disposer)
         return newVariable
     }
 

--- a/SnailTests/Extensions/NotificationCenterExtensions.swift
+++ b/SnailTests/Extensions/NotificationCenterExtensions.swift
@@ -7,6 +7,8 @@ import XCTest
 @testable import Snail
 
 class NotificationCenterTests: XCTestCase {
+    private let disposer = Disposer()
+
     func testNotification() {
         let exp = expectation(description: "notification")
         let notificationName = UIResponder.keyboardWillShowNotification
@@ -15,7 +17,7 @@ class NotificationCenterTests: XCTestCase {
         subject.subscribe(onNext: { notification in
             notifcation = notification
             exp.fulfill()
-        })
+        }).add(to: disposer)
         NotificationCenter.default.post(name: notificationName, object: nil)
         waitForExpectations(timeout: 3) { error in
             XCTAssertNil(error)
@@ -32,11 +34,11 @@ class NotificationCenterTests: XCTestCase {
         let willShowName = UIResponder.keyboardWillShowNotification
         let willHideName = UIResponder.keyboardWillHideNotification
 
-        NotificationCenter.default.observeEvent(willShowName).subscribe(onNext: { _ in gotWillShow = true })
+        NotificationCenter.default.observeEvent(willShowName).subscribe(onNext: { _ in gotWillShow = true }).add(to: disposer)
         NotificationCenter.default.observeEvent(willHideName).subscribe(onNext: { _ in
             gotWillHide = true
             willHide.fulfill()
-        })
+        }).add(to: disposer)
 
         NotificationCenter.default.post(name: willShowName, object: nil)
         NotificationCenter.default.post(name: willHideName, object: nil)

--- a/SnailTests/FailTests.swift
+++ b/SnailTests/FailTests.swift
@@ -13,6 +13,7 @@ class FailTests: XCTestCase {
     private var strings: [String]?
     private var error: Error?
     private var done: Bool?
+    private let disposer = Disposer()
 
     override func setUp() {
         super.setUp()
@@ -26,7 +27,7 @@ class FailTests: XCTestCase {
             onNext: { [weak self] in self?.strings?.append($0) },
             onError: { self.error = $0 },
             onDone: { self.done = true }
-        )
+        ).add(to: disposer)
     }
 
     func testOnErrorIsRun() {
@@ -49,7 +50,7 @@ class FailTests: XCTestCase {
         subject?.subscribe(
             onError: { newError = $0 as? TestError },
             onDone: { self.done = true }
-        )
+        ).add(to: disposer)
 
         XCTAssertEqual(newError, .test)
         XCTAssertNil(done)

--- a/SnailTests/ReplayTests.swift
+++ b/SnailTests/ReplayTests.swift
@@ -6,6 +6,7 @@ import XCTest
 
 class ReplayTests: XCTestCase {
     private var subject: Replay<String>?
+    private let disposer = Disposer()
 
     override func setUp() {
         super.setUp()
@@ -70,7 +71,7 @@ class ReplayTests: XCTestCase {
             self.subject?.on(.main).subscribe(onNext: { _ in
                 isMainQueue = Thread.isMainThread
                 exp.fulfill()
-            })
+            }).add(to: self.disposer)
         }
 
         waitForExpectations(timeout: 2) { error in

--- a/SnailTests/UniqueTests.swift
+++ b/SnailTests/UniqueTests.swift
@@ -5,12 +5,14 @@ import XCTest
 @testable import Snail
 
 class UniqueTests: XCTestCase {
+    private let disposer = Disposer()
+
     func testVariableChanges() {
         var events: [String?] = []
         let subject = Unique<String?>(nil)
         subject.asObservable().subscribe(
             onNext: { string in events.append(string) }
-        )
+        ).add(to: disposer)
         subject.value = nil
         subject.value = "1"
         subject.value = "2"
@@ -28,7 +30,7 @@ class UniqueTests: XCTestCase {
         subject.value = "new"
         var result: String?
 
-        subject.asObservable().subscribe(onNext: { result = $0 })
+        subject.asObservable().subscribe(onNext: { result = $0 }).add(to: disposer)
 
         XCTAssertEqual("new", result)
     }
@@ -37,7 +39,7 @@ class UniqueTests: XCTestCase {
         let subject = Unique("initial")
         var result: String?
 
-        subject.asObservable().subscribe(onNext: { result = $0 })
+        subject.asObservable().subscribe(onNext: { result = $0 }).add(to: disposer)
 
         XCTAssertEqual("initial", result)
     }
@@ -49,7 +51,7 @@ class UniqueTests: XCTestCase {
 
         subject.map { $0.count }.asObservable().subscribe(onNext: { count in
             subjectCharactersCount = count
-        })
+        }).add(to: disposer)
 
         XCTAssertEqual(subject.value.count, subjectCharactersCount)
     }
@@ -58,7 +60,7 @@ class UniqueTests: XCTestCase {
         let subject = Unique("initial")
         var subjectCharactersCount: Int?
 
-        subject.map { $0.count }.asObservable().subscribe(onNext: { subjectCharactersCount = $0 })
+        subject.map { $0.count }.asObservable().subscribe(onNext: { subjectCharactersCount = $0 }).add(to: disposer)
 
         XCTAssertEqual(subject.value.count, subjectCharactersCount)
     }
@@ -66,7 +68,7 @@ class UniqueTests: XCTestCase {
     func testVariableHandlesEquatableArrays() {
         var events: [[String]] = []
         let subject = Unique<[String]>(["1", "2"])
-        subject.asObservable().subscribe(onNext: { array in events.append(array) })
+        subject.asObservable().subscribe(onNext: { array in events.append(array) }).add(to: disposer)
 
         subject.value = ["1", "2"]
         subject.value = ["2", "1"]
@@ -82,7 +84,7 @@ class UniqueTests: XCTestCase {
         let subject = Unique<[String]?>(nil)
         subject.asObservable().subscribe(
             onNext: { array in events.append(array) }
-        )
+        ).add(to: disposer)
         subject.value = ["1", "2"]
         subject.value = nil
         subject.value = nil

--- a/SnailTests/VariableTests.swift
+++ b/SnailTests/VariableTests.swift
@@ -5,12 +5,14 @@ import XCTest
 @testable import Snail
 
 class VariableTests: XCTestCase {
+    private let disposer = Disposer()
+
     func testVariableChanges() {
         var events: [String?] = []
         let subject = Variable<String?>(nil)
         subject.asObservable().subscribe(
             onNext: { string in events.append(string) }
-        )
+        ).add(to: disposer)
         subject.value = "1"
         subject.value = "2"
         XCTAssertEqual(events[0], nil)
@@ -24,7 +26,7 @@ class VariableTests: XCTestCase {
         subject.value = "new"
         var result: String?
 
-        subject.asObservable().subscribe(onNext: { result = $0 })
+        subject.asObservable().subscribe(onNext: { result = $0 }).add(to: disposer)
 
         XCTAssertEqual("new", result)
     }
@@ -33,7 +35,7 @@ class VariableTests: XCTestCase {
         let subject = Variable("initial")
         var result: String?
 
-        subject.asObservable().subscribe(onNext: { result = $0 })
+        subject.asObservable().subscribe(onNext: { result = $0 }).add(to: disposer)
 
         XCTAssertEqual("initial", result)
     }
@@ -43,7 +45,7 @@ class VariableTests: XCTestCase {
         subject.value = "new"
         var subjectCharactersCount: Int?
 
-        subject.map { $0.count }.asObservable().subscribe(onNext: { subjectCharactersCount = $0 })
+        subject.map { $0.count }.asObservable().subscribe(onNext: { subjectCharactersCount = $0 }).add(to: disposer)
 
         XCTAssertEqual(subject.value.count, subjectCharactersCount)
     }
@@ -52,7 +54,7 @@ class VariableTests: XCTestCase {
         let subject = Variable("initial")
         var subjectCharactersCount: Int?
 
-        subject.map { $0.count }.asObservable().subscribe(onNext: { subjectCharactersCount = $0 })
+        subject.map { $0.count }.asObservable().subscribe(onNext: { subjectCharactersCount = $0 }).add(to: disposer)
 
         XCTAssertEqual(subject.value.count, subjectCharactersCount)
     }
@@ -63,11 +65,11 @@ class VariableTests: XCTestCase {
 
         subject.map { $0.count }.asObservable().subscribe(onNext: { _ in
             firedCount += 1
-        })
+        }).add(to: disposer)
 
         subject.value = "sameValue"
 
-        XCTAssertTrue(firedCount == 1)
+        XCTAssertEqual(firedCount, 1)
     }
 
     func testVariableFireCounts() {
@@ -76,7 +78,7 @@ class VariableTests: XCTestCase {
 
         subject.map { $0.count }.asObservable().subscribe(onNext: { _ in
             firedCount += 1
-        })
+        }).add(to: disposer)
 
         subject.value = "sameValue"
 
@@ -89,7 +91,7 @@ class VariableTests: XCTestCase {
 
         subject.map { _ in return () }.asObservable().subscribe(onNext: { _ in
             fired = true
-        })
+        }).add(to: disposer)
 
         XCTAssertTrue(fired)
     }
@@ -98,7 +100,7 @@ class VariableTests: XCTestCase {
         let subject = Variable("one")
         let observedVariable = Variable("two")
 
-        subject.bind(to: observedVariable)
+        subject.bind(to: observedVariable).add(to: disposer)
         XCTAssertEqual(subject.value, "two")
 
         observedVariable.value = "three"


### PR DESCRIPTION
This PR removes the `@discardableResult` attribute from the observable's `subscribe` method. The compiler will now warn when a subscription is unused. See [this RFC](https://docs.google.com/document/d/1gxfNxSg5yNO8-O-zkDvXTCXdNLJbne014ahnM4zzA6A/edit#heading=h.qyjn4yqpfilb) for more context.